### PR TITLE
Feat/comfyui integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
     - [Download the weights](#download-the-weights)
     - [Command-line inference](#command-line-inference)
     - [Interactive Gradio demo](#interactive-gradio-demo)
+    - [ComfyUI](#comfyui)
     - [Prompt Enhancer](#prompt-enhancer)
     - [Python API](#python-api)
   - [Fine-tuning](#fine-tuning)
@@ -425,6 +426,16 @@ Other examples:
 auk-gradio --share
 auk-gradio --port 8000
 ```
+
+### ComfyUI
+
+The [`comfyui/ComfyUI-AuK`](comfyui/ComfyUI-AuK) custom-node directory provides
+**AuK Model Loader** and **AuK Generate / Edit** nodes for instruction TTS,
+zero-shot TTS, and speech editing. Install AuK with
+`pip install -e ".[comfyui]"`, link the node package into
+`ComfyUI/custom_nodes`, and import the included workflow. See the
+[ComfyUI guide](docs/COMFYUI.md) for weights, Prompt Enhancer, the shared
+30-second sequence limit, playback, and saving.
 
 ### Prompt Enhancer
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,9 @@ uv pip install -e .
 # Core inference + Gradio + Prompt Enhancer + ASR
 uv pip install -e ".[gradio]"
 
+# Core inference + ComfyUI nodes + Prompt Enhancer + ASR
+uv pip install -e ".[comfyui]"
+
 # Core inference + fine-tuning
 uv pip install -e ".[train]"
 
@@ -204,6 +207,9 @@ pip install -e .
 
 # Core inference + Gradio + Prompt Enhancer + ASR
 pip install -e ".[gradio]"
+
+# Core inference + ComfyUI nodes + Prompt Enhancer + ASR
+pip install -e ".[comfyui]"
 
 # Core inference + fine-tuning
 pip install -e ".[train]"
@@ -429,13 +435,16 @@ auk-gradio --port 8000
 
 ### ComfyUI
 
-The [`comfyui/ComfyUI-AuK`](comfyui/ComfyUI-AuK) custom-node directory provides
-**AuK Model Loader** and **AuK Generate / Edit** nodes for instruction TTS,
-zero-shot TTS, and speech editing. Install AuK with
-`pip install -e ".[comfyui]"`, link the node package into
-`ComfyUI/custom_nodes`, and import the included workflow. See the
-[ComfyUI guide](docs/COMFYUI.md) for weights, Prompt Enhancer, the shared
-30-second sequence limit, playback, and saving.
+Use **AuK Base** and **AuK-Flash** for speech generation, editing, enhancement,
+and separation through **AuK Model Loader** and **AuK Generate / Edit**.
+Install `.[comfyui]` in the environment that runs ComfyUI, link
+[`comfyui/ComfyUI-AuK`](comfyui/ComfyUI-AuK) into `ComfyUI/custom_nodes`, and
+open the reusable [`auk.json`](comfyui/workflows/auk.json) workflow.
+
+The included workflow starts with Base, PE disabled, and a 3-second text-only
+example. See the [ComfyUI guide](docs/COMFYUI.md) for installation,
+shared `.env` configuration, Flash settings, audio input/output,
+and the integration's 30-second source-plus-target sequence limit.
 
 ### Prompt Enhancer
 

--- a/comfyui/ComfyUI-AuK/__init__.py
+++ b/comfyui/ComfyUI-AuK/__init__.py
@@ -1,0 +1,4 @@
+from .nodes import comfy_entrypoint
+
+
+__all__ = ["comfy_entrypoint"]

--- a/comfyui/ComfyUI-AuK/nodes.py
+++ b/comfyui/ComfyUI-AuK/nodes.py
@@ -1,0 +1,428 @@
+from __future__ import annotations
+
+import logging
+import math
+import os
+import tempfile
+import threading
+from pathlib import Path
+
+import torch
+import torchaudio
+from comfy_api.v0_0_2 import ComfyExtension, io
+from omegaconf import OmegaConf
+
+import auk
+from auk.infer.infer_auk import AukInfer
+
+
+logger = logging.getLogger("ComfyUI-AuK")
+
+MAX_SEQUENCE_SECONDS = 30.0
+QWEN_AUDIO_SAMPLE_RATE = 16_000
+AUK_ENGINE = io.Custom("AUK_ENGINE")
+
+
+class AuKEngine:
+    def __init__(self, inference: AukInfer):
+        self.inference = inference
+        self.lock = threading.Lock()
+
+
+ENGINE_CACHE: dict[tuple[str, str, str, str, str], AuKEngine] = {}
+ENGINE_CACHE_LOCK = threading.Lock()
+
+
+def resolve_path(path: str) -> Path:
+    expanded = Path(os.path.expandvars(path)).expanduser()
+    if expanded.is_absolute():
+        return expanded.resolve()
+    auk_home = os.environ.get("AUK_HOME")
+    base = Path(auk_home).expanduser() if auk_home else Path(auk.__file__).resolve().parents[2]
+    return (base / expanded).resolve()
+
+
+def normalize_audio(audio: dict | None) -> tuple[torch.Tensor, int] | None:
+    if audio is None:
+        return None
+    if not isinstance(audio, dict) or "waveform" not in audio or "sample_rate" not in audio:
+        raise ValueError("input_audio must be a ComfyUI AUDIO value with waveform and sample_rate.")
+
+    waveform = audio["waveform"]
+    sample_rate = audio["sample_rate"]
+    if not torch.is_tensor(waveform) or waveform.ndim != 3:
+        shape = tuple(waveform.shape) if torch.is_tensor(waveform) else type(waveform).__name__
+        raise ValueError(f"input_audio waveform must have shape [B, C, T], got {shape}.")
+    if waveform.shape[0] != 1:
+        raise ValueError(f"AuK accepts one audio sample per run, got batch size {waveform.shape[0]}.")
+    if waveform.shape[1] < 1 or waveform.shape[2] < 1:
+        raise ValueError(f"input_audio waveform is empty: {tuple(waveform.shape)}.")
+    if not isinstance(sample_rate, int) or sample_rate <= 0:
+        raise ValueError(f"input_audio sample_rate must be a positive integer, got {sample_rate!r}.")
+
+    waveform = waveform[0].detach().to(device="cpu", dtype=torch.float32)
+    if not torch.isfinite(waveform).all():
+        raise ValueError("input_audio waveform contains NaN or Inf.")
+    if waveform.shape[0] > 1:
+        waveform = waveform.mean(dim=0, keepdim=True)
+    return waveform.contiguous(), sample_rate
+
+
+def prepare_model_audio(
+    audio: tuple[torch.Tensor, int] | None,
+    target_sample_rate: int,
+) -> tuple[tuple[torch.Tensor, int] | None, object | None]:
+    if audio is None:
+        return None, None
+    waveform, sample_rate = audio
+    model_waveform = waveform
+    if sample_rate != target_sample_rate:
+        model_waveform = torchaudio.functional.resample(waveform, sample_rate, target_sample_rate)
+    qwen_waveform = model_waveform
+    if target_sample_rate != QWEN_AUDIO_SAMPLE_RATE:
+        qwen_waveform = torchaudio.functional.resample(model_waveform, target_sample_rate, QWEN_AUDIO_SAMPLE_RATE)
+    return (model_waveform.contiguous(), target_sample_rate), qwen_waveform.squeeze(0).contiguous().numpy()
+
+
+def validate_sequence_duration(engine: AuKEngine, source_audio: tuple[torch.Tensor, int] | None, target_seconds: float) -> None:
+    if not math.isfinite(target_seconds) or target_seconds <= 0:
+        raise ValueError(f"Target duration must be a finite value greater than 0 seconds, got {target_seconds!r}.")
+    sample_rate = engine.inference.target_sample_rate
+    downsample_rate = engine.inference.downsample_rate
+    source_frames = source_audio[0].shape[-1] // downsample_rate if source_audio is not None else 0
+    target_frames = max(1, math.ceil(target_seconds * sample_rate / downsample_rate))
+    max_frames = int(MAX_SEQUENCE_SECONDS * sample_rate / downsample_rate)
+    if source_frames + target_frames > max_frames:
+        source_seconds = source_frames * downsample_rate / sample_rate
+        applied_target_seconds = target_frames * downsample_rate / sample_rate
+        raise ValueError(
+            f"AuK's source/reference plus generated target sequence is "
+            f"{source_seconds + applied_target_seconds:.2f}s "
+            f"({source_seconds:.2f}s + {applied_target_seconds:.2f}s after model-frame rounding), "
+            f"exceeding the {MAX_SEQUENCE_SECONDS:.0f}s limit."
+        )
+
+
+class AuKModelLoader(io.ComfyNode):
+    @classmethod
+    def define_schema(cls) -> io.Schema:
+        devices = [f"cuda:{index}" for index in range(torch.cuda.device_count())]
+        devices.append("cpu")
+        default_device = devices[0]
+        default_dtype = "bf16" if default_device.startswith("cuda") else "fp32"
+        return io.Schema(
+            node_id="AuKModelLoader",
+            display_name="AuK Model Loader",
+            category="AuK",
+            description=(
+                "Load AuK or AuK-Flash and reuse the same engine for identical settings. "
+                "Models remain resident until ComfyUI exits; changing settings can load another copy."
+            ),
+            inputs=[
+                io.String.Input(
+                    "checkpoint_path",
+                    default="ckpts/AuK/auk_base.safetensors",
+                    tooltip="AuK or AuK-Flash checkpoint. Relative paths use AUK_HOME, then the installed AuK checkout.",
+                ),
+                io.String.Input(
+                    "config_path",
+                    default="",
+                    tooltip="Optional config.yaml override. Empty uses config.yaml beside the checkpoint.",
+                ),
+                io.String.Input(
+                    "qwen_path",
+                    default="ckpts/Qwen2.5-Omni-3B",
+                    tooltip="Qwen2.5-Omni-3B directory. Relative paths use AUK_HOME, then the installed AuK checkout.",
+                ),
+                io.Combo.Input(
+                    "device",
+                    options=devices,
+                    default=default_device,
+                    tooltip="Visible CUDA device or CPU.",
+                ),
+                io.Combo.Input(
+                    "dtype",
+                    options=["bf16", "fp16", "fp32"],
+                    default=default_dtype,
+                    tooltip="Inference autocast dtype. The Qwen encoder is loaded in bf16 by AuK.",
+                ),
+            ],
+            outputs=[AUK_ENGINE.Output("engine", display_name="engine")],
+        )
+
+    @classmethod
+    def execute(
+        cls,
+        checkpoint_path: str,
+        config_path: str,
+        qwen_path: str,
+        device: str,
+        dtype: str,
+    ) -> io.NodeOutput:
+        checkpoint = resolve_path(checkpoint_path.strip())
+        if not checkpoint.is_file():
+            raise ValueError(f"AuK checkpoint not found: {checkpoint}")
+        vae = checkpoint.parent / "vae.safetensors"
+        if not vae.is_file():
+            raise ValueError(f"AuK VAE not found next to the checkpoint: {vae}")
+
+        config = resolve_path(config_path.strip()) if config_path.strip() else checkpoint.parent / "config.yaml"
+        config = config.resolve()
+        if not config.is_file():
+            raise ValueError(f"AuK config not found: {config}")
+
+        model_config = OmegaConf.load(config)
+        model_name = str(model_config.model.get("name", ""))
+        if model_name not in {"AuK", "AuK-Flash"}:
+            raise ValueError(f"Unsupported AuK model name in {config}: {model_name!r}")
+
+        qwen_setting = qwen_path.strip() or str(model_config.model.text_encoder.text_encoder_path)
+        qwen = resolve_path(qwen_setting)
+        if not qwen.is_dir():
+            raise ValueError(f"Qwen2.5-Omni-3B directory not found: {qwen}")
+
+        device = device.strip()
+        if device != "cpu" and device != "cuda" and not (device.startswith("cuda:") and device.removeprefix("cuda:").isdigit()):
+            raise ValueError(f"Unsupported device {device!r}; use cpu, cuda, or cuda:N.")
+        if device.startswith("cuda") and not torch.cuda.is_available():
+            raise ValueError(f"CUDA device requested but CUDA is unavailable: {device}")
+        if device.startswith("cuda:") and int(device.removeprefix("cuda:")) >= torch.cuda.device_count():
+            raise ValueError(f"CUDA device is out of range: {device}; visible device count is {torch.cuda.device_count()}.")
+        if dtype not in {"bf16", "fp16", "fp32"}:
+            raise ValueError(f"Unsupported dtype {dtype!r}; use bf16, fp16, or fp32.")
+        if device == "cpu" and dtype != "fp32":
+            raise ValueError("CPU inference requires dtype=fp32; fp16/bf16 autocast is only applied on CUDA.")
+        if device.startswith("cuda") and dtype == "bf16" and not torch.cuda.is_bf16_supported():
+            raise ValueError(f"The selected CUDA device does not support bf16: {device}.")
+
+        cache_key = (str(checkpoint), str(config), str(qwen), device, dtype)
+        with ENGINE_CACHE_LOCK:
+            engine = ENGINE_CACHE.get(cache_key)
+            if engine is None:
+                logger.info("Loading %s from %s on %s (%s)", model_name, checkpoint, device, dtype)
+                engine = AuKEngine(
+                    inference=AukInfer(
+                        config_path=str(config),
+                        ckpt_path=str(checkpoint),
+                        device=device,
+                        dtype=dtype,
+                        qwen_path=str(qwen),
+                    )
+                )
+                ENGINE_CACHE[cache_key] = engine
+        return io.NodeOutput(engine)
+
+
+class AuKGenerateEdit(io.ComfyNode):
+    @classmethod
+    def define_schema(cls) -> io.Schema:
+        return io.Schema(
+            node_id="AuKGenerateEdit",
+            display_name="AuK Generate / Edit",
+            category="AuK",
+            description=(
+                "Run instruction TTS, zero-shot TTS, or speech editing. "
+                "The source/reference and generated target share one 30-second sequence budget."
+            ),
+            inputs=[
+                AUK_ENGINE.Input("engine"),
+                io.String.Input(
+                    "instruction",
+                    multiline=True,
+                    default=(
+                        'Generate speech based on the following description: "a calm, warm female voice". '
+                        'The content to speak is: "Hello, welcome to AuK.".'
+                    ),
+                    tooltip="Natural-language AuK request. Prompt Enhancer can convert a free-form request into the model instruction.",
+                ),
+                io.Float.Input(
+                    "generation_seconds",
+                    default=0.0,
+                    min=0.0,
+                    max=MAX_SEQUENCE_SECONDS,
+                    step=0.1,
+                    display_mode=io.NumberDisplay.slider,
+                    tooltip=(
+                        "Generated target duration in seconds. 0 lets Prompt Enhancer estimate it. "
+                        "When Prompt Enhancer is disabled, enter a value above 0."
+                    ),
+                ),
+                io.Boolean.Input(
+                    "use_prompt_enhancer",
+                    display_name="Enable Prompt Enhancer",
+                    default=True,
+                    label_on="enabled",
+                    label_off="disabled",
+                    tooltip="Uses the same PE preparation path as the AuK Gradio demo. Credentials are read from server environment variables.",
+                ),
+                io.Int.Input(
+                    "seed",
+                    default=42,
+                    min=0,
+                    max=0x7FFFFFFFFFFFFFFF,
+                    control_after_generate=io.ControlAfterGenerate.fixed,
+                    tooltip="Seeds both reference VAE encoding and target sampling.",
+                ),
+                io.Audio.Input(
+                    "input_audio",
+                    optional=True,
+                    tooltip=(
+                        "Reference audio for zero-shot TTS or source audio for editing. "
+                        "Leave unconnected for instruction TTS. Batch size must be 1; channels are averaged to mono."
+                    ),
+                ),
+                io.Int.Input(
+                    "nfe_steps",
+                    default=32,
+                    min=4,
+                    max=64,
+                    step=1,
+                    advanced=True,
+                    tooltip="Base AuK sampling steps. AuK-Flash requires 4.",
+                ),
+                io.Float.Input(
+                    "cfg_strength",
+                    default=2.0,
+                    min=0.0,
+                    max=5.0,
+                    step=0.1,
+                    advanced=True,
+                    tooltip="Base AuK classifier-free guidance. AuK-Flash requires 0.",
+                ),
+                io.Float.Input(
+                    "sway_sampling_coef",
+                    default=-1.0,
+                    min=-1.0,
+                    max=1.0,
+                    step=0.1,
+                    advanced=True,
+                    tooltip="Base AuK sway sampling coefficient. AuK-Flash requires the default -1 placeholder.",
+                ),
+            ],
+            outputs=[
+                io.Audio.Output("generated_audio", display_name="generated audio"),
+                io.String.Output("enhanced_instruction", display_name="model instruction"),
+                io.String.Output("prompt_enhancer_info", display_name="Prompt Enhancer info"),
+            ],
+        )
+
+    @classmethod
+    def execute(
+        cls,
+        engine: AuKEngine,
+        instruction: str,
+        generation_seconds: float,
+        use_prompt_enhancer: bool,
+        seed: int,
+        input_audio: dict | None = None,
+        nfe_steps: int = 32,
+        cfg_strength: float = 2.0,
+        sway_sampling_coef: float = -1.0,
+    ) -> io.NodeOutput:
+        instruction = instruction.strip()
+        if not instruction:
+            raise ValueError("AuK instruction is empty.")
+        if not math.isfinite(float(generation_seconds)) or not 0.0 <= float(generation_seconds) <= MAX_SEQUENCE_SECONDS:
+            raise ValueError(f"generation_seconds must be between 0 and {MAX_SEQUENCE_SECONDS:.0f}, got {generation_seconds!r}.")
+        if engine.inference.is_flash and (int(nfe_steps) != 4 or float(cfg_strength) != 0.0 or float(sway_sampling_coef) != -1.0):
+            raise ValueError(
+                "AuK-Flash requires NFE steps=4, CFG strength=0, and sway=-1; these controls are fixed by its recipe."
+            )
+
+        audio = normalize_audio(input_audio)
+        prepared = None
+        bridge_path = None
+        final_instruction = instruction
+        prompt_enhancer_info = "Prompt Enhancer: disabled"
+        target_seconds = float(generation_seconds)
+
+        try:
+            if use_prompt_enhancer:
+                if audio is not None:
+                    waveform, sample_rate = audio
+                    descriptor, bridge_path = tempfile.mkstemp(prefix="auk_comfy_pe_", suffix=".wav")
+                    os.close(descriptor)
+                    torchaudio.save(
+                        bridge_path,
+                        waveform,
+                        sample_rate,
+                        encoding="PCM_F",
+                        bits_per_sample=32,
+                    )
+
+                from auk.infer.pe import PromptEnhancer, PromptEnhancerError
+
+                try:
+                    prepared = PromptEnhancer().prepare(
+                        instruction,
+                        bridge_path,
+                        target_duration=target_seconds if target_seconds > 0 else None,
+                    )
+                except (PromptEnhancerError, ValueError, FileNotFoundError) as error:
+                    raise ValueError(f"Prompt Enhancer failed: {type(error).__name__}: {error}") from error
+                final_instruction = prepared.instruction
+                target_seconds = target_seconds if target_seconds > 0 else prepared.gen_seconds
+                if prepared.audio:
+                    prepared_waveform, prepared_sample_rate = torchaudio.load(prepared.audio)
+                    audio = normalize_audio({"waveform": prepared_waveform.unsqueeze(0), "sample_rate": prepared_sample_rate})
+                else:
+                    audio = None
+
+                task = prepared.task_type
+                if prepared.operation_subtype:
+                    task = f"{task} / {prepared.operation_subtype}"
+                asr_text = prepared.asr.text if prepared.asr and prepared.asr.text else ""
+                prompt_enhancer_info = f"Task: {task}\nTarget Duration: {target_seconds:.2f} s\nASR Content: {asr_text}"
+            elif target_seconds <= 0:
+                raise ValueError("Duration must be greater than 0 when Prompt Enhancer is disabled.")
+
+            model_audio, qwen_audio = prepare_model_audio(audio, engine.inference.target_sample_rate)
+            validate_sequence_duration(engine, model_audio, target_seconds)
+
+            content = [{"type": "text", "text": final_instruction}]
+            if qwen_audio is not None:
+                content.append({"type": "audio", "audio": qwen_audio})
+            messages = [{"role": "user", "content": content}]
+
+            with engine.lock:
+                torch.manual_seed(int(seed))
+                generated_waveform, sample_rate = engine.inference.generate(
+                    messages,
+                    audio=model_audio,
+                    gen_seconds=target_seconds,
+                    nfe=int(nfe_steps),
+                    cfg_strength=float(cfg_strength),
+                    sway_sampling_coef=float(sway_sampling_coef),
+                    seed=int(seed),
+                )
+        finally:
+            if prepared is not None:
+                prepared.cleanup()
+            if bridge_path is not None:
+                try:
+                    os.remove(bridge_path)
+                except FileNotFoundError:
+                    pass
+
+        generated_waveform = generated_waveform.detach().to(device="cpu", dtype=torch.float32)
+        if generated_waveform.ndim == 1:
+            generated_waveform = generated_waveform.unsqueeze(0)
+        if generated_waveform.ndim != 2 or generated_waveform.shape[-1] == 0:
+            raise RuntimeError(f"AuK returned invalid audio shape: {tuple(generated_waveform.shape)}.")
+        if not torch.isfinite(generated_waveform).all():
+            raise RuntimeError("AuK returned audio containing NaN or Inf.")
+
+        audio_output = {
+            "waveform": generated_waveform.unsqueeze(0),
+            "sample_rate": int(sample_rate),
+        }
+        return io.NodeOutput(audio_output, final_instruction, prompt_enhancer_info)
+
+
+class AuKExtension(ComfyExtension):
+    async def get_node_list(self) -> list[type[io.ComfyNode]]:
+        return [AuKModelLoader, AuKGenerateEdit]
+
+
+async def comfy_entrypoint() -> AuKExtension:
+    return AuKExtension()

--- a/comfyui/workflows/auk.json
+++ b/comfyui/workflows/auk.json
@@ -1,0 +1,353 @@
+{
+  "last_node_id": 5,
+  "last_link_id": 3,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "AuKModelLoader",
+      "pos": [
+        20,
+        120
+      ],
+      "size": [
+        400,
+        260
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "checkpoint_path",
+          "type": "STRING",
+          "widget": {
+            "name": "checkpoint_path"
+          },
+          "link": null
+        },
+        {
+          "name": "config_path",
+          "type": "STRING",
+          "widget": {
+            "name": "config_path"
+          },
+          "link": null
+        },
+        {
+          "name": "qwen_path",
+          "type": "STRING",
+          "widget": {
+            "name": "qwen_path"
+          },
+          "link": null
+        },
+        {
+          "name": "device",
+          "type": "COMBO",
+          "widget": {
+            "name": "device"
+          },
+          "link": null
+        },
+        {
+          "name": "dtype",
+          "type": "COMBO",
+          "widget": {
+            "name": "dtype"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "engine",
+          "type": "AUK_ENGINE",
+          "links": [
+            1
+          ],
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "AuKModelLoader"
+      },
+      "widgets_values": [
+        "ckpts/AuK/auk_base.safetensors",
+        "",
+        "ckpts/Qwen2.5-Omni-3B",
+        "cuda:0",
+        "bf16"
+      ]
+    },
+    {
+      "id": 2,
+      "type": "LoadAudio",
+      "pos": [
+        20,
+        430
+      ],
+      "size": [
+        400,
+        180
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "audio",
+          "type": "COMBO",
+          "widget": {
+            "name": "audio"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "AUDIO",
+          "type": "AUDIO",
+          "links": null,
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadAudio"
+      },
+      "widgets_values": [
+        "auk_input.wav"
+      ]
+    },
+    {
+      "id": 3,
+      "type": "AuKGenerateEdit",
+      "pos": [
+        500,
+        90
+      ],
+      "size": [
+        470,
+        420
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "engine",
+          "type": "AUK_ENGINE",
+          "link": 1
+        },
+        {
+          "name": "instruction",
+          "type": "STRING",
+          "widget": {
+            "name": "instruction"
+          },
+          "link": null
+        },
+        {
+          "name": "generation_seconds",
+          "type": "FLOAT",
+          "widget": {
+            "name": "generation_seconds"
+          },
+          "link": null
+        },
+        {
+          "name": "use_prompt_enhancer",
+          "type": "BOOLEAN",
+          "widget": {
+            "name": "use_prompt_enhancer"
+          },
+          "link": null
+        },
+        {
+          "name": "seed",
+          "type": "INT",
+          "widget": {
+            "name": "seed"
+          },
+          "link": null
+        },
+        {
+          "name": "nfe_steps",
+          "type": "INT",
+          "widget": {
+            "name": "nfe_steps"
+          },
+          "link": null
+        },
+        {
+          "name": "cfg_strength",
+          "type": "FLOAT",
+          "widget": {
+            "name": "cfg_strength"
+          },
+          "link": null
+        },
+        {
+          "name": "sway_sampling_coef",
+          "type": "FLOAT",
+          "widget": {
+            "name": "sway_sampling_coef"
+          },
+          "link": null
+        },
+        {
+          "name": "input_audio",
+          "type": "AUDIO",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "generated audio",
+          "type": "AUDIO",
+          "links": [
+            2,
+            3
+          ],
+          "slot_index": 0
+        },
+        {
+          "name": "model instruction",
+          "type": "STRING",
+          "links": null,
+          "slot_index": 1
+        },
+        {
+          "name": "Prompt Enhancer info",
+          "type": "STRING",
+          "links": null,
+          "slot_index": 2
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "AuKGenerateEdit"
+      },
+      "widgets_values": [
+        "Generate speech based on the following description: \"A calm, warm female voice with a clear, moderate pace\". The content to speak is: \"Hello, welcome to AuK.\".",
+        3.0,
+        false,
+        42,
+        32,
+        2.0,
+        -1.0
+      ]
+    },
+    {
+      "id": 4,
+      "type": "PreviewAudio",
+      "pos": [
+        1050,
+        70
+      ],
+      "size": [
+        320,
+        110
+      ],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "audio",
+          "type": "AUDIO",
+          "link": 2
+        }
+      ],
+      "outputs": [
+        {
+          "name": "audio",
+          "type": "AUDIO",
+          "links": null,
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "PreviewAudio"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 5,
+      "type": "SaveAudioAdvanced",
+      "pos": [
+        1050,
+        240
+      ],
+      "size": [
+        320,
+        130
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "audio",
+          "type": "AUDIO",
+          "link": 3
+        }
+      ],
+      "outputs": [
+        {
+          "name": "audio",
+          "type": "AUDIO",
+          "links": null,
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "SaveAudioAdvanced"
+      },
+      "widgets_values": [
+        "auk/output",
+        "flac"
+      ],
+      "widgets_values_named": {
+        "filename_prefix": "auk/output",
+        "format": "flac"
+      }
+    }
+  ],
+  "links": [
+    [
+      1,
+      1,
+      0,
+      3,
+      0,
+      "AUK_ENGINE"
+    ],
+    [
+      2,
+      3,
+      0,
+      4,
+      0,
+      "AUDIO"
+    ],
+    [
+      3,
+      3,
+      0,
+      5,
+      0,
+      "AUDIO"
+    ]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 0.9,
+      "offset": [
+        140,
+        180
+      ]
+    }
+  },
+  "version": 0.4
+}

--- a/docs/COMFYUI.md
+++ b/docs/COMFYUI.md
@@ -1,0 +1,153 @@
+# ComfyUI-AuK
+
+ComfyUI-AuK exposes the existing AuK inference and Prompt Enhancer paths as two
+ComfyUI V3 nodes using the stable `comfy_api.v0_0_2` interface:
+
+- **AuK Model Loader** loads AuK or AuK-Flash and returns an `AUK_ENGINE`.
+- **AuK Generate / Edit** runs instruction TTS, zero-shot TTS, or speech
+  editing and returns standard ComfyUI `AUDIO`.
+
+The generated waveform has shape `[B, C, T]` and can be connected directly to
+**Preview Audio** or **Save Audio (Advanced)**.
+
+## Installation
+
+Use an existing dedicated ComfyUI environment. Install the PyTorch/CUDA build
+required by your server first, then install AuK and its ComfyUI dependencies
+through the repository's single optional dependency group:
+
+```bash
+cd /path/to/ComfyUI
+source .venv/bin/activate
+
+cd /path/to/AuK
+pip install -e ".[comfyui]"
+
+test ! -e /path/to/ComfyUI/custom_nodes/ComfyUI-AuK
+ln -s /path/to/AuK/comfyui/ComfyUI-AuK \
+  /path/to/ComfyUI/custom_nodes/ComfyUI-AuK
+```
+
+Do not install a second copy of this node under `custom_nodes`; duplicate copies
+can register the same node IDs twice. The package has not been published to
+ComfyUI Manager or the Registry.
+
+## Weights
+
+Download the AuK, optional AuK-Flash, and Qwen2.5-Omni-3B files as described in
+the root [README](../README.md#download-the-weights). The default node values
+expect:
+
+```text
+ckpts/
+├── AuK/
+│   ├── auk_base.safetensors
+│   ├── config.yaml
+│   └── vae.safetensors
+├── AuK-Flash/
+│   ├── auk_flash.safetensors
+│   ├── config.yaml
+│   └── vae.safetensors
+└── Qwen2.5-Omni-3B/
+```
+
+Relative loader paths resolve against `AUK_HOME`, then against the installed
+AuK checkout. Set it before starting ComfyUI when the weights are stored with a
+different checkout:
+
+```bash
+export AUK_HOME=/path/to/AuK
+```
+
+You can also enter absolute checkpoint, config, and Qwen paths in the loader.
+The VAE is selected from the checkpoint directory by the existing AuK loader.
+
+## Start ComfyUI
+
+Start ComfyUI from its own directory:
+
+```bash
+cd /path/to/ComfyUI
+source .venv/bin/activate
+python main.py --listen 127.0.0.1 --port 8188
+```
+
+`8188` is ComfyUI's default port. Bind to `0.0.0.0` only after confirming the
+platform access controls; open the actual forwarded address or
+`http://127.0.0.1:PORT`, not `0.0.0.0`.
+
+## Workflows
+
+Import the single reusable UI workflow:
+
+- [`auk.json`](../comfyui/workflows/auk.json)
+
+This JSON file is a ComfyUI canvas export, not a Python dependency. It stores
+the nodes, links, widget values, and layout needed for one-click browser import.
+The Python nodes still work if it is deleted.
+
+The workflow leaves **Load Audio** disconnected by default:
+
+- For instruction TTS, leave it disconnected.
+- For zero-shot TTS, connect a reference recording to **input audio**.
+- For editing, enhancement, and separation, connect the audio to process.
+
+Change the instruction and target duration for the selected task. Separate
+workflow or API-prompt JSON copies are intentionally not kept because the same
+two AuK nodes execute every task.
+
+## Generate and edit
+
+For instruction TTS, leave **input audio** unconnected. For zero-shot TTS,
+connect a voice reference. For editing, connect the source recording. The task
+is carried by the instruction, using the same message format and templates as
+the AuK CLI, Python API, and [Cookbook](COOKBOOK.md). The node accepts
+one audio sample per execution and averages multichannel input to mono.
+
+The loader caches one engine for each resolved checkpoint, config, Qwen path,
+device, and dtype combination. Repeated generations with the same loader
+settings reuse it. Models remain resident on the selected device; there is no
+automatic ComfyUI VRAM offload. Restart ComfyUI to release them. Loading another
+combination can keep another complete engine in memory.
+
+Base AuK exposes NFE, CFG, and sway controls. AuK-Flash uses its fixed 4-step,
+CFG-off recipe; set NFE to `4`, CFG to `0`, and sway to `-1`. The node rejects
+other values instead of silently ignoring them.
+
+## Prompt Enhancer
+
+**Enable Prompt Enhancer** defaults to enabled, matching the Gradio demo. It
+uses the same classification, ASR, rewrite, duration, audio preprocessing, and
+error paths. The node also returns the model instruction and a compact PE
+summary. Disabling it skips PE construction and network/ASR calls; enter an
+explicit positive duration.
+
+Load credentials only into the server process:
+
+```bash
+set -a
+source /path/to/AuK/.env
+set +a
+python main.py --listen 127.0.0.1 --port 8188
+```
+
+Keys are not node inputs, workflow values, log fields, or repository files.
+Audio preprocessing uses temporary files only when PE requires the existing
+file-based path, and removes them after generation.
+
+## 30-second limit
+
+AuK was trained with audio targets up to 30 seconds. During inference, source or
+reference latents are prepended to generated target latents in the model
+sequence, so this integration enforces one shared 30-second budget after
+resampling and latent-frame rounding:
+
+```text
+source/reference duration + generated target duration <= 30 seconds
+```
+
+Instruction TTS has no audio prefix, so its target can use the full budget.
+Audio-backed tasks have less target time available. The node checks both the
+actual connected audio and the manual or PE-derived target duration before
+inference. It raises a clear error when the sequence is too long; it never
+truncates or automatically splits and joins long audio.

--- a/docs/COMFYUI.md
+++ b/docs/COMFYUI.md
@@ -1,153 +1,69 @@
-# ComfyUI-AuK
+# AuK in ComfyUI
 
-ComfyUI-AuK exposes the existing AuK inference and Prompt Enhancer paths as two
-ComfyUI V3 nodes using the stable `comfy_api.v0_0_2` interface:
+AuK and AuK-Flash use the same models, Prompt Enhancer (PE), and task
+instructions as the [Gradio demo](../README.md#interactive-gradio-demo).
+Follow the README for [installation](../README.md#installation),
+[weights](../README.md#download-the-weights), and PE configuration; use the
+[Cookbook](COOKBOOK.md) for task examples.
 
-- **AuK Model Loader** loads AuK or AuK-Flash and returns an `AUK_ENGINE`.
-- **AuK Generate / Edit** runs instruction TTS, zero-shot TTS, or speech
-  editing and returns standard ComfyUI `AUDIO`.
+## Connect to ComfyUI
 
-The generated waveform has shape `[B, C, T]` and can be connected directly to
-**Preview Audio** or **Save Audio (Advanced)**.
-
-## Installation
-
-Use an existing dedicated ComfyUI environment. Install the PyTorch/CUDA build
-required by your server first, then install AuK and its ComfyUI dependencies
-through the repository's single optional dependency group:
+Install `.[comfyui]` in the Python environment that runs ComfyUI, then link
+the nodes and start ComfyUI from that environment:
 
 ```bash
-cd /path/to/ComfyUI
-source .venv/bin/activate
-
-cd /path/to/AuK
-pip install -e ".[comfyui]"
-
-test ! -e /path/to/ComfyUI/custom_nodes/ComfyUI-AuK
 ln -s /path/to/AuK/comfyui/ComfyUI-AuK \
   /path/to/ComfyUI/custom_nodes/ComfyUI-AuK
-```
 
-Do not install a second copy of this node under `custom_nodes`; duplicate copies
-can register the same node IDs twice. The package has not been published to
-ComfyUI Manager or the Registry.
-
-## Weights
-
-Download the AuK, optional AuK-Flash, and Qwen2.5-Omni-3B files as described in
-the root [README](../README.md#download-the-weights). The default node values
-expect:
-
-```text
-ckpts/
-├── AuK/
-│   ├── auk_base.safetensors
-│   ├── config.yaml
-│   └── vae.safetensors
-├── AuK-Flash/
-│   ├── auk_flash.safetensors
-│   ├── config.yaml
-│   └── vae.safetensors
-└── Qwen2.5-Omni-3B/
-```
-
-Relative loader paths resolve against `AUK_HOME`, then against the installed
-AuK checkout. Set it before starting ComfyUI when the weights are stored with a
-different checkout:
-
-```bash
 export AUK_HOME=/path/to/AuK
-```
-
-You can also enter absolute checkpoint, config, and Qwen paths in the loader.
-The VAE is selected from the checkpoint directory by the existing AuK loader.
-
-## Start ComfyUI
-
-Start ComfyUI from its own directory:
-
-```bash
 cd /path/to/ComfyUI
-source .venv/bin/activate
 python main.py --listen 127.0.0.1 --port 8188
 ```
 
-`8188` is ComfyUI's default port. Bind to `0.0.0.0` only after confirming the
-platform access controls; open the actual forwarded address or
-`http://127.0.0.1:PORT`, not `0.0.0.0`.
+Keep one node-package copy under `custom_nodes`. To enable PE, load the same
+AuK `.env` used by Gradio into this shell **before starting ComfyUI**; the nodes
+do not load it automatically. Open the local address or the server's forwarded
+address, using its configured port.
 
-## Workflows
+## Run a workflow
 
-Import the single reusable UI workflow:
+Open [`auk.json`](../comfyui/workflows/auk.json), check the paths and device in
+**AuK Model Loader**, and click **Run**. The included example uses **AuK Base**,
+**PE disabled**, and a **3-second** target. Its output connects to **Preview
+Audio** and **Save Audio (Advanced)**, which saves FLAC files with the
+`auk/output` prefix under ComfyUI's output directory.
 
-- [`auk.json`](../comfyui/workflows/auk.json)
+In **AuK Generate / Edit**, enter an instruction from the Cookbook:
 
-This JSON file is a ComfyUI canvas export, not a Python dependency. It stores
-the nodes, links, widget values, and layout needed for one-click browser import.
-The Python nodes still work if it is deleted.
+- **Instruction TTS:** leave `input_audio` disconnected.
+- **Zero-shot TTS:** upload a reference voice with **Load Audio** and connect it
+  to `input_audio`.
+- **Editing, enhancement, or separation:** connect the audio to process.
 
-The workflow leaves **Load Audio** disconnected by default:
+Replace the **Load Audio** placeholder with an uploaded file before using it.
+With PE enabled, `generation_seconds=0` estimates the target duration; a
+positive value overrides the estimate. With PE disabled, supply a positive
+value. Newly added Generate / Edit nodes default to PE enabled, unlike the
+included workflow. Connect the two text outputs to **Preview as Text** to see
+the final instruction and PE/ASR summary.
 
-- For instruction TTS, leave it disconnected.
-- For zero-shot TTS, connect a reference recording to **input audio**.
-- For editing, enhancement, and separation, connect the audio to process.
+To use **AuK-Flash**, change `checkpoint_path` to
+`ckpts/AuK-Flash/auk_flash.safetensors` and set `nfe_steps=4`,
+`cfg_strength=0`, and `sway_sampling_coef=-1`. Leave `config_path` empty to
+load the config beside the selected checkpoint. Relative model paths use
+`AUK_HOME`, or the installed AuK checkout when it is unset; absolute paths
+are also supported.
 
-Change the instruction and target duration for the selected task. Separate
-workflow or API-prompt JSON copies are intentionally not kept because the same
-two AuK nodes execute every task.
+## ComfyUI-specific behavior
 
-## Generate and edit
-
-For instruction TTS, leave **input audio** unconnected. For zero-shot TTS,
-connect a voice reference. For editing, connect the source recording. The task
-is carried by the instruction, using the same message format and templates as
-the AuK CLI, Python API, and [Cookbook](COOKBOOK.md). The node accepts
-one audio sample per execution and averages multichannel input to mono.
-
-The loader caches one engine for each resolved checkpoint, config, Qwen path,
-device, and dtype combination. Repeated generations with the same loader
-settings reuse it. Models remain resident on the selected device; there is no
-automatic ComfyUI VRAM offload. Restart ComfyUI to release them. Loading another
-combination can keep another complete engine in memory.
-
-Base AuK exposes NFE, CFG, and sway controls. AuK-Flash uses its fixed 4-step,
-CFG-off recipe; set NFE to `4`, CFG to `0`, and sway to `-1`. The node rejects
-other values instead of silently ignoring them.
-
-## Prompt Enhancer
-
-**Enable Prompt Enhancer** defaults to enabled, matching the Gradio demo. It
-uses the same classification, ASR, rewrite, duration, audio preprocessing, and
-error paths. The node also returns the model instruction and a compact PE
-summary. Disabling it skips PE construction and network/ASR calls; enter an
-explicit positive duration.
-
-Load credentials only into the server process:
-
-```bash
-set -a
-source /path/to/AuK/.env
-set +a
-python main.py --listen 127.0.0.1 --port 8188
-```
-
-Keys are not node inputs, workflow values, log fields, or repository files.
-Audio preprocessing uses temporary files only when PE requires the existing
-file-based path, and removes them after generation.
-
-## 30-second limit
-
-AuK was trained with audio targets up to 30 seconds. During inference, source or
-reference latents are prepended to generated target latents in the model
-sequence, so this integration enforces one shared 30-second budget after
-resampling and latent-frame rounding:
-
-```text
-source/reference duration + generated target duration <= 30 seconds
-```
-
-Instruction TTS has no audio prefix, so its target can use the full budget.
-Audio-backed tasks have less target time available. The node checks both the
-actual connected audio and the manual or PE-derived target duration before
-inference. It raises a clear error when the sequence is too long; it never
-truncates or automatically splits and joins long audio.
+- **Duration:** source/reference + generated target must fit within **30
+  seconds**, after PE preprocessing, resampling, and model-frame rounding.
+  Long Cookbook examples may need shorter inputs; the node does not split
+  audio automatically.
+- **Memory:** models stay resident on the selected device and are reused.
+  Switching model settings may load another engine; restart ComfyUI to release
+  them. Automatic ComfyUI VRAM offload is not supported.
+- **Audio:** each execution accepts one input sample and averages channels to
+  mono. The node returns the generated waveform directly, without Gradio's
+  extra loudness processing for lyric editing and vocal extraction; output
+  levels may differ.

--- a/docs/COOKBOOK.md
+++ b/docs/COOKBOOK.md
@@ -2,6 +2,13 @@
 
 AuK uses a unified ChatML-style input format, with each task specified by a natural-language instruction and audio supplied when required. This guide provides English and Chinese instruction templates, along with CLI and Python examples.
 
+For ComfyUI, use these instruction templates in **AuK Generate / Edit** and
+connect reference/source audio as described in the [ComfyUI guide](COMFYUI.md).
+With PE enabled, `generation_seconds=0` enables automatic duration estimation;
+with PE disabled, supply a positive duration. The ComfyUI integration also
+checks a shared 30-second source/reference-plus-target budget, so long examples
+may require shorter audio clips.
+
 ## Contents
 
 - [Python API Setup](#python-api-setup)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,19 @@ gradio = [
     "modelscope>=1.20,<2",
 ]
 
+# ComfyUI nodes, Prompt Enhancer, cloud ASR, and local SenseVoice fallback.
+# Install with: pip install -e ".[comfyui]"
+comfyui = [
+    "PyYAML>=6.0",
+    "silero-vad>=6.0",
+    "WeTextProcessing>=1.2.0",
+    "pyloudnorm>=0.2.0",
+    "openai>=1.0.0",
+    "tencentcloud-sdk-python-asr>=3.0.0",
+    "funasr>=1.3,<2",
+    "modelscope>=1.20,<2",
+]
+
 # Extra deps for full DiT fine-tuning (src/auk/train/train.py). Not needed for inference.
 # Install with: pip install -e ".[train]"
 train = [

--- a/src/auk/infer/infer_auk.py
+++ b/src/auk/infer/infer_auk.py
@@ -140,8 +140,22 @@ class AukInfer:
 
     # ------------------------------------------------------------------ helpers
 
-    def _load_audio(self, wav_path: str) -> tuple[torch.Tensor, float]:
-        audio, sr = torchaudio.load(wav_path)
+    def _load_audio(self, source: str | tuple[torch.Tensor, int]) -> tuple[torch.Tensor, float]:
+        if isinstance(source, str):
+            audio, sr = torchaudio.load(source)
+        else:
+            audio, sr = source
+            audio = audio.detach().to(device="cpu", dtype=torch.float32)
+            if audio.ndim == 1:
+                audio = audio.unsqueeze(0)
+            if audio.ndim != 2:
+                raise ValueError(f"Audio tensor must have shape [channels, samples], got {tuple(audio.shape)}.")
+            if not isinstance(sr, int) or sr <= 0:
+                raise ValueError(f"Audio sample rate must be a positive integer, got {sr!r}.")
+            if audio.shape[-1] == 0:
+                raise ValueError("Audio tensor is empty.")
+            if not torch.isfinite(audio).all():
+                raise ValueError("Audio tensor contains NaN or Inf.")
         if audio.shape[0] > 1:
             audio = audio.mean(dim=0, keepdim=True)
         ref_rms = torch.sqrt(torch.mean(torch.square(audio)))
@@ -225,7 +239,7 @@ class AukInfer:
         self,
         messages: list,  # caller-composed ChatML turns (must carry a user audio item)
         *,
-        audio: str | None = None,
+        audio: str | tuple[torch.Tensor, int] | None = None,
         gen_seconds: float | None = None,
         nfe: int = 32,
         cfg_strength: float = 2.0,


### PR DESCRIPTION
## Summary and motivation

Add ComfyUI support for AuK Base and AuK-Flash so users can run speech generation, editing, enhancement, and separation in audio workflows.

- Add **AuK Model Loader** and **AuK Generate / Edit** nodes using ComfyUI's V3 API.
- Reuse AuK inference and Prompt Enhancer, including task classification, ASR, instruction rewriting, and duration estimation.
- Accept in-memory audio tensors in `AukInfer` while preserving file-path inputs.
- Provide a reusable workflow with audio loading, preview, and saving.
- Add the `comfyui` optional dependency group and concise documentation linked to the existing README and Cookbook.
- Validate audio inputs, Flash sampling settings, and the shared 30-second source/reference-plus-target budget.

## Related issue

N/A — no related issue linked.

## Change type

- [ ] Bug fix
- [x] New feature or task
- [ ] Performance or memory improvement
- [ ] Model, checkpoint, or training change
- [x] Compatibility or dependency change
- [x] Documentation, refactor, or maintenance

## Validation

- [x] `ruff check .`
- [x] `ruff format --check .`
- [x] `pre-commit run --all-files`
- [x] `python3 -m compileall -q src`
- [x] Relevant Gradio, inference, or training test

Commands and results:

```text
Contributor-reported checks:
  ruff check .                       Passed
  ruff format --check .              Passed
  pre-commit run --all-files         Passed

Independently verified on the PR checkout:
  python3 -m compileall -q src                    Passed
  python3 -m compileall -q comfyui/ComfyUI-AuK     Passed
  git diff --check                              Passed

Live ComfyUI inference:
  AuK Base: 15/15 representative task cases completed successfully.
  AuK-Flash: 3/3 cases completed successfully:
    zero-shot TTS, speech content editing, and speech separation.

All tested outputs decoded successfully and contained finite, nonzero audio.
Representative generated audio completed browser playback.
ASR readback verified the Base Chinese TTS text and the requested
“半斤地瓜烧” → “两只大烧鸡” content replacement.
```

Checks not run and reason:
- Training validation: no training changes.
- Separate Gradio UI smoke test: no Gradio UI changes; live inference validation focused on ComfyUI.
- A full Flash task sweep and quantitative perceptual-quality evaluation were not performed.
- Ruff and pre-commit results above were supplied by the contributor and were not independently rerun during PR-description preparation.

## Model and runtime validation

- AuK variant: Both.
- Checkpoint source and revision: Existing server checkpoints at `ckpts/AuK/auk_base.safetensors` and `ckpts/AuK-Flash/auk_flash.safetensors`, with Qwen2.5-Omni-3B. Exact checkpoint download revisions/hashes were not recorded.
- GPU and VRAM: NVIDIA H20, approximately 95 GiB VRAM per visible device; inference used `cuda:0`. Peak memory was not profiled.
- Input or audio description: Existing repository samples under `assets/demo-input-audio`. Base covered 15 task categories, one case per category. Speech separation used a 10-second excerpt; other selected inputs were unchanged.
- Inference or training command:

  ```bash
  # Run from ComfyUI using its activated Python environment.
  # Load the AuK PE environment configuration before startup.
  python main.py --listen 127.0.0.1 --port 8188
  ```

  Import `comfyui/workflows/auk.json`, upload the task input, connect `Load Audio` to `input_audio`, and run with PE enabled and automatic duration estimation.

  - Base: `nfe_steps=32`, `cfg_strength=2.0`, `sway_sampling_coef=-1`.
  - Flash: select the Flash checkpoint and use `nfe_steps=4`, `cfg_strength=0`, `sway_sampling_coef=-1`.
  - Both: `dtype=bf16`.

- Observed result: Model loading, PE/ASR processing, generation, and audio output succeeded for the cases listed above. The exact deployed server Git revision was not captured; these results are deployment smoke-test evidence rather than a fully revision-pinned regression run.

## Impact

- Output quality: No model-quality improvement is claimed. The nodes return generated waveforms without Gradio's additional loudness processing for lyric editing and vocal extraction. One Base lyric-editing output had approximately 3.54% near-full-scale samples, indicating a potential clipping risk.
- Latency and GPU memory: Base test jobs took approximately 6.9–14.1 seconds each. Flash took 28.6 seconds for the first tested job, including model loading, followed by 9.1 and 6.7 seconds. These are end-to-end job times including PE/ASR, not isolated inference benchmarks. Engines remain cached on the selected device without automatic ComfyUI VRAM offload.
- Public API or configuration: `AukInfer.generate(audio=...)` additionally accepts `(waveform, sample_rate)` tuples. Existing file-path inputs remain supported. ComfyUI adds node settings and optional `AUK_HOME` path resolution.
- Checkpoint or data compatibility: Existing AuK and AuK-Flash checkpoints are used without format changes. ComfyUI enforces a shared 30-second source/reference-plus-target limit.
- New dependencies: Add a `comfyui` optional dependency group using PE/ASR packages already available through the Gradio extra. ComfyUI itself is installed separately.

## Documentation and provenance

- [x] User-facing behavior, configuration, examples, and comments are updated where needed.
- [x] No credentials, private URLs, personal data, model weights, datasets, or generated artifact collections are committed.
- [ ] Third-party code, models, data, and audio have documented sources and compatible licenses.
- [x] Submitted audio and data may legally and ethically be shared for the proposed use.
- [x] Material AI assistance is disclosed below, or no material AI assistance was used.

Documentation, provenance, and AI-assistance notes:

README, the Cookbook, and `docs/COMFYUI.md` describe installation, workflow usage, PE configuration reuse, Flash settings, and ComfyUI-specific limitations.

Validation reused existing repository audio; no audio, model weights, or generated output collections are added by this PR. The submitted-audio item is therefore N/A. A separate license audit of existing model and demo-audio assets was not performed, so the third-party provenance item remains unchecked.

OpenAI Codex assisted with documentation review and editing, validation automation, and preparation of this PR description. The contributor remains responsible for reviewing the changes and confirming the reported results.

## Final checklist

- [ ] The change is focused and the complete diff has been self-reviewed.
- [x] Unrelated formatting and generated edits have been removed.
- [ ] Another contributor can reproduce the reported validation.
- [ ] The contribution follows `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`.

## Reviewer notes

- Review tensor-based audio input handling and the shared duration check.
- Flash requires the matching checkpoint/config and fixed `4 / 0 / -1` sampling settings.
- The included workflow disables PE and uses a 3-second target; newly added Generate / Edit nodes default to PE enabled.
- Gradio and ComfyUI share inference and PE preparation, but their output loudness processing differs.
- Exact checkpoint revisions and the deployed server commit should be recorded for fully reproducible runtime validation.
- Final author review, provenance confirmation, and contribution-policy confirmation remain pending.