### PR TITLE
cpu_offload to save memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,24 @@ To use AuK-Flash, set:
 ```
 AuK-Flash use 4 fixed time steps and set CFG=0.
 
+**Lower VRAM usage (CUDA only)**
+
+Add `--cpu_offload` to `auk-infer` or `auk-gradio`, set `cpu_offload=True`
+when constructing `AukInfer`, or enable `cpu_offload` in ComfyUI's
+**AuK Model Loader**. It is disabled by default and works with both AuK variants.
+
+Peak VRAM measured on one NVIDIA A800-SXM4-80GB with bf16 inference:
+
+| Model | Input | CPU offload disabled | CPU offload enabled | VRAM saved |
+|---|---|---:|---:|---:|
+| AuK | Text only, 1.5 s output | 24.78 GiB | 16.75 GiB | 8.03 GiB (32.4%) |
+| AuK | 5 s reference audio | 25.00 GiB | 16.98 GiB | 8.02 GiB (32.1%) |
+| AuK-Flash | Text only, 1.5 s output | 24.77 GiB | 16.75 GiB | 8.02 GiB (32.4%) |
+| AuK-Flash | 5 s reference audio | 24.97 GiB | 16.98 GiB | 7.99 GiB (32.0%) |
+
+The table reports `torch.cuda.max_memory_allocated`; actual usage depends on
+input length, dtype, hardware, and software versions.
+
 ### Interactive Gradio demo
 
 Install the Gradio dependencies with `pip install -e ".[gradio]"` (or the

--- a/comfyui/ComfyUI-AuK/nodes.py
+++ b/comfyui/ComfyUI-AuK/nodes.py
@@ -29,7 +29,7 @@ class AuKEngine:
         self.lock = threading.Lock()
 
 
-ENGINE_CACHE: dict[tuple[str, str, str, str, str], AuKEngine] = {}
+ENGINE_CACHE: dict[tuple[str, str, str, str, str, bool], AuKEngine] = {}
 ENGINE_CACHE_LOCK = threading.Lock()
 
 
@@ -116,7 +116,7 @@ class AuKModelLoader(io.ComfyNode):
             category="AuK",
             description=(
                 "Load AuK or AuK-Flash and reuse the same engine for identical settings. "
-                "Models remain resident until ComfyUI exits; changing settings can load another copy."
+                "Engines remain cached until ComfyUI exits; changing settings can load another copy."
             ),
             inputs=[
                 io.String.Input(
@@ -146,6 +146,15 @@ class AuKModelLoader(io.ComfyNode):
                     default=default_dtype,
                     tooltip="Inference autocast dtype. The Qwen encoder is loaded in bf16 by AuK.",
                 ),
+                io.Boolean.Input(
+                    "cpu_offload",
+                    default=False,
+                    optional=True,
+                    tooltip=(
+                        "Offload the Qwen text encoder and DiT to CPU when idle to reduce VRAM use. "
+                        "The VAE remains on CUDA (slower inference)."
+                    ),
+                ),
             ],
             outputs=[AUK_ENGINE.Output("engine", display_name="engine")],
         )
@@ -158,6 +167,7 @@ class AuKModelLoader(io.ComfyNode):
         qwen_path: str,
         device: str,
         dtype: str,
+        cpu_offload: bool = False,
     ) -> io.NodeOutput:
         checkpoint = resolve_path(checkpoint_path.strip())
         if not checkpoint.is_file():
@@ -195,7 +205,7 @@ class AuKModelLoader(io.ComfyNode):
         if device.startswith("cuda") and dtype == "bf16" and not torch.cuda.is_bf16_supported():
             raise ValueError(f"The selected CUDA device does not support bf16: {device}.")
 
-        cache_key = (str(checkpoint), str(config), str(qwen), device, dtype)
+        cache_key = (str(checkpoint), str(config), str(qwen), device, dtype, cpu_offload)
         with ENGINE_CACHE_LOCK:
             engine = ENGINE_CACHE.get(cache_key)
             if engine is None:
@@ -207,6 +217,7 @@ class AuKModelLoader(io.ComfyNode):
                         device=device,
                         dtype=dtype,
                         qwen_path=str(qwen),
+                        cpu_offload=cpu_offload,
                     )
                 )
                 ENGINE_CACHE[cache_key] = engine

--- a/docs/COMFYUI.md
+++ b/docs/COMFYUI.md
@@ -60,9 +60,14 @@ are also supported.
   seconds**, after PE preprocessing, resampling, and model-frame rounding.
   Long Cookbook examples may need shorter inputs; the node does not split
   audio automatically.
-- **Memory:** models stay resident on the selected device and are reused.
-  Switching model settings may load another engine; restart ComfyUI to release
-  them. Automatic ComfyUI VRAM offload is not supported.
+- **Memory:** models stay resident on the selected device and are reused by default.
+  Enable `cpu_offload` in **AuK Model Loader** to keep the Qwen text encoder
+  and DiT in CPU RAM while idle and move them to CUDA only when needed. The
+  VAE remains resident on the selected CUDA device. This trades inference
+  speed for lower VRAM use; the VAE plus each active component and its
+  intermediate tensors must still fit. Switching model settings may load
+  another engine; restart ComfyUI to release them. This opt-in mode is
+  separate from ComfyUI's automatic VRAM management.
 - **Audio:** each execution accepts one input sample and averages channels to
   mono. The node returns the generated waveform directly, without Gradio's
   extra loudness processing for lyric editing and vocal extraction; output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     # transformers / gradio / librosa. Re-enable this pin only if you need to lock 1.x on py3.10.
     # "numpy<=1.26.4; python_version<='3.10'",
     "safetensors",
+    "accelerate>=0.33.0",
 ]
 
 [project.optional-dependencies]
@@ -63,7 +64,6 @@ comfyui = [
 # Extra deps for full DiT fine-tuning (src/auk/train/train.py). Not needed for inference.
 # Install with: pip install -e ".[train]"
 train = [
-    "accelerate>=0.33.0",
     "ema-pytorch",
     "tensorboard",
     "matplotlib",

--- a/src/auk/infer/infer_auk.py
+++ b/src/auk/infer/infer_auk.py
@@ -32,9 +32,14 @@ class AukInfer:
         device: str | None = None,
         dtype: str = "bf16",
         qwen_path: str | None = None,
+        cpu_offload: bool = False,
     ):
         self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
         self.dtype = _DTYPE_MAP.get(dtype, torch.bfloat16)
+        self.cpu_offload = cpu_offload
+        if cpu_offload and (not self.device.startswith("cuda") or not torch.cuda.is_available()):
+            raise ValueError("cpu_offload requires a CUDA device.")
+        load_device = "cpu" if cpu_offload else self.device
 
         config = OmegaConf.load(config_path)
         if qwen_path:
@@ -80,6 +85,9 @@ class AukInfer:
             vae_ckpt=vae_config.vae_model_path,
             map_location="cpu",
         )
+        # Keep the VAE resident on the inference device. Only Qwen and DiT are
+        # offloaded, preserving the baseline VAE weight_norm execution path
+        # and avoiding VAE CPU<->GPU transfers.
         vae_model = vae_model.to(self.device).eval()
         vae_model.requires_grad_(False)
         self.vae_model = vae_model
@@ -104,8 +112,19 @@ class AukInfer:
 
         # --- load EMA weights (strip "ema_model." prefix; text_encoder.* comes from Qwen snapshot) ---
         self._load_ema_weights(model, ckpt_path)
-        self.model = model.to(self.device)
+        self.model = model.to(load_device)
         self.model.eval()
+
+        if cpu_offload:
+            from accelerate import cpu_offload_with_hook
+            from accelerate.utils import set_module_tensor_to_device
+
+            # Keep only the small layer-fusion parameters on GPU, not the child models.
+            for name, _ in self.model.named_parameters(recurse=False):
+                set_module_tensor_to_device(self.model, name, self.device)
+            _, text_hook = cpu_offload_with_hook(self.model.text_encoder, self.device)
+            _, transformer_hook = cpu_offload_with_hook(self.model.transformer, self.device, prev_module_hook=text_hook)
+            self._offload_hooks = (text_hook, transformer_hook)
 
     def _load_ema_weights(self, model: CFMEdit, ckpt_path: str):
         logger.info(f"Loading model checkpoint from {ckpt_path} ...")
@@ -222,6 +241,8 @@ class AukInfer:
         if torch.isnan(gen_latent).any() or torch.isinf(gen_latent).any():
             raise RuntimeError("Generated latent contains NaN/Inf.")
 
+        if self.cpu_offload:
+            self._offload_hooks[1].offload()
         gen_latent = self.vae_model.denormalize(gen_latent)
         gen_latent = gen_latent.permute(0, 2, 1)  # [1, D, T_new]
 
@@ -277,17 +298,25 @@ class AukInfer:
             sway_sampling_coef = None
             t_grid = [0.0, 0.07612049579620361, 0.2928932309150696, 0.6173166036605835, 1.0]
 
-        audio_out = self._run(
-            ref_audio,
-            ref_rms,
-            messages,
-            gen_latent_len,
-            nfe=nfe,
-            cfg_strength=cfg_strength,
-            sway_sampling_coef=sway_sampling_coef,
-            t_grid=t_grid,
-            seed=seed,
-        )
+        try:
+            audio_out = self._run(
+                ref_audio,
+                ref_rms,
+                messages,
+                gen_latent_len,
+                nfe=nfe,
+                cfg_strength=cfg_strength,
+                sway_sampling_coef=sway_sampling_coef,
+                t_grid=t_grid,
+                seed=seed,
+            )
+        finally:
+            if self.cpu_offload:
+                self.model.transformer.clear_cache()
+                for hook in self._offload_hooks:
+                    hook.offload()
+                with torch.cuda.device(self.device):
+                    torch.cuda.empty_cache()
         return audio_out, self.target_sample_rate
 
 

--- a/src/auk/infer/infer_cli.py
+++ b/src/auk/infer/infer_cli.py
@@ -48,6 +48,11 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--dtype", choices=["fp16", "bf16", "fp32"], default="bf16", help="autocast dtype")
     p.add_argument("--seed", type=int, default=None, help="random seed")
     p.add_argument("--device", default=None, help="cuda / cuda:0 / cpu (auto if unset)")
+    p.add_argument(
+        "--cpu_offload",
+        action="store_true",
+        help="offload the Qwen text encoder and DiT to CPU when idle; keep the VAE on CUDA",
+    )
 
     p.add_argument("--output", "-o", required=True, help="output wav path")
     return p
@@ -72,6 +77,7 @@ def main():
         device=args.device,
         dtype=args.dtype,
         qwen_path=args.qwen_path,
+        cpu_offload=args.cpu_offload,
     )
 
     # no --audio => Instruct TTS; generate() appends the |<no_prompt_audio>| marker for the text-only turn

--- a/src/auk/infer/infer_gradio.py
+++ b/src/auk/infer/infer_gradio.py
@@ -601,6 +601,11 @@ def main():
     p.add_argument("--qwen_path", default=None)
     p.add_argument("--dtype", choices=["fp16", "bf16", "fp32"], default="bf16")
     p.add_argument("--device", default=None)
+    p.add_argument(
+        "--cpu_offload",
+        action="store_true",
+        help="offload the Qwen text encoder and DiT to CPU when idle; keep the VAE on CUDA",
+    )
     p.add_argument("--host", default="0.0.0.0")
     p.add_argument("--port", type=int, default=7860)
     p.add_argument("--share", action="store_true")
@@ -629,7 +634,7 @@ def main():
         CKPT_PATHS[label] = checkpoint
         CONFIG_PATHS[label] = config
 
-    ENGINE_KWARGS.update(device=args.device, dtype=args.dtype, qwen_path=args.qwen_path)
+    ENGINE_KWARGS.update(device=args.device, dtype=args.dtype, qwen_path=args.qwen_path, cpu_offload=args.cpu_offload)
     DEVICE_PATHS[BASE_LABEL] = args.base_device
     DEVICE_PATHS[FLASH_LABEL] = args.flash_device
 


### PR DESCRIPTION
## Summary and motivation

AuK currently loads the Qwen2.5-Omni text encoder, DiT, and VAE on the selected
CUDA device for the lifetime of an inference engine. This requires about
25 GiB of peak allocated VRAM for the tested Base and Flash configurations.

This PR adds an opt-in `cpu_offload` mode for inference:

- Qwen and DiT stay in CPU RAM while idle and are moved to CUDA when needed.
- DiT remains on CUDA throughout the sampling loop.
- The VAE remains resident on CUDA for reference encoding and output decoding.
- Request cleanup offloads Qwen and DiT after both successful and failed
  inference.
- The option is exposed through `AukInfer`, `auk-infer`, `auk-gradio`, and
  ComfyUI.
- ComfyUI includes `cpu_offload` in its engine cache key, while older workflows
  that omit the option continue to use the default value `False`.
- `accelerate>=0.33.0` is now a core inference dependency rather than a
  training-only dependency.

Keeping the VAE on CUDA is intentional. It preserves the original VAE
`weight_norm` execution path and avoids changing the effective VAE weights.
In the tested environment, offload enabled and disabled produced bitwise
identical Base and Flash audio across text-only inference, reference-audio
inference, five seeds, and five additional editing/TTS tasks.

The user-visible outcome is an approximately 8 GiB reduction in peak allocated
VRAM, with increased inference latency and host RAM usage.

## Related issue

N/A — no related issue is currently linked.

## Change type

- [ ] Bug fix
- [x] New feature or task
- [x] Performance or memory improvement
- [ ] Model, checkpoint, or training change
- [x] Compatibility or dependency change
- [x] Documentation, refactor, or maintenance

## Validation

<!-- Run every applicable check. Explain any unchecked item below. -->

- [x] `ruff check .`
- [x] `ruff format --check .`
- [ ] `pre-commit run --all-files`
- [x] `python3 -m compileall -q src`
- [x] Relevant Gradio, inference, or training test

Commands and results:

```text
$ /data/miniconda3/envs/env-3.10/bin/ruff check .
All checks passed!

$ /data/miniconda3/envs/env-3.10/bin/ruff format --check .
15 files already formatted

$ /data/miniconda3/envs/env-3.10/bin/python -m compileall -q src
exit code 0

$ /data/miniconda3/envs/env-3.10/bin/pre-commit run --files \
    README.md \
    comfyui/ComfyUI-AuK/nodes.py \
    docs/COMFYUI.md \
    pyproject.toml \
    src/auk/infer/infer_auk.py \
    src/auk/infer/infer_cli.py \
    src/auk/infer/infer_gradio.py
ruff linter..............................................................Passed
ruff formatter...........................................................Passed
ruff sorter..............................................................Passed
check yaml...........................................(no files to check)Skipped

Real inference validation:

- Base and Flash, CPU offload disabled/enabled
- text-only and reference-audio inputs
- five measured seeds per model/input combination
- additional zero-shot TTS, content editing, pitch editing, de-accent, and
  whisper-conversion inputs
- post-commit Flash reference-audio smoke test

All VAE-resident offload outputs were bitwise identical to the corresponding
non-offloaded outputs:

max_abs_error = 0
RMSE = 0
relative_L2 = 0
```

Checks not run and reason:

`pre-commit run --all-files` was run, but the repository-wide Ruff sorter
modified the import layout in the unrelated existing file
`src/auk/infer/pe.py`. That unrelated edit was reverted to keep this PR
focused. All pre-commit hooks pass when run on the files changed by this PR.

## Model and runtime validation

<!-- Complete for behavior-affecting changes; write N/A otherwise. -->

- AuK variant: Both Base and Flash
- Checkpoint source and revision:
  - `tencent/AuK`, revision
    `790742b71a4430120daf2b2099192abae449eb9f`
  - `tencent/AuK-Flash`, revision
    `575b92f0895f75180bf2cbd35f2e176c5732b8ed`
  - `Qwen/Qwen2.5-Omni-3B`, revision
    `f75b40e3da2003cdd6e1829b1f420ca70797c34e`
- GPU and VRAM: NVIDIA A800-SXM4-80GB, 80 GiB, driver 580.105.08
- Input or audio description:
  - 1.5-second text-only TTS
  - approximately 5-second 8 kHz reference audio
  - bundled zero-shot TTS, content-editing, pitch-editing, de-accent, and
    whisper-conversion audio
- Inference or training command:

```text
export LD_LIBRARY_PATH="$(
  printf '%s' "$LD_LIBRARY_PATH" |
  tr ':' '\n' |
  grep -v '/cuda-12.4/compat' |
  paste -sd: -
)"

CUDA_VISIBLE_DEVICES=7 \
/data/miniconda3/envs/env-3.10/bin/python \
  /apdcephfs_tj5/share_303787284/zhikangniu/codes/\
AuK-cpu-offload-test-results/20260911-113322/\
vae-resident-experiment/scripts/run_case.py \
  --source-root \
  /apdcephfs_tj5/share_303787284/zhikangniu/codes/\
AuK-cpu-offload-vae-resident-experiment \
  --config \
  /apdcephfs_tj5/share_303787284/zhikangniu/ckpts/AuK-Flash/config.yaml \
  --checkpoint \
  /apdcephfs_tj5/share_303787284/zhikangniu/ckpts/\
AuK-Flash/auk_flash.safetensors \
  --qwen \
  /apdcephfs_tj5/share_303787284/zhikangniu/ckpts/Qwen2.5-Omni-3B \
  --device cuda:0 \
  --dtype bf16 \
  --offload-mode true \
  --instruction \
  "Preserve all speakers, remove noise and reverberation, and output clean speech of the same length." \
  --audio \
  /apdcephfs_tj5/share_303787284/zhikangniu/codes/\
AuK-cpu-offload-test/assets/demo-input-audio/se/se-zh-1-input.wav \
  --seed 424242 \
  --repeats 1 \
  --output-dir /tmp/auk-offload-validation \
  --case-id flash-offload-reference
```

- Observed result:
  - real Base and Flash inference passed;
  - Qwen and DiT were offloaded while idle;
  - the VAE remained on `cuda:0`;
  - the VAE retained all 228 legacy `weight_norm` modules;
  - offload enabled/disabled outputs were bitwise identical in all tested
    VAE-resident comparisons;
  - controlled inference failures cleaned up correctly and the engine remained
    reusable;
  - Gradio and ComfyUI real workflows produced audio;
  - Base/Flash and offload on/off passed on all eight physical GPUs in the
    broader validation run.

## Impact

<!-- Describe measurable effects or write N/A. -->

- Output quality:
  - No numerical output difference was observed between offload disabled and
    VAE-resident offload in the tested A800/bf16 environment.
  - Base/Flash text-only and reference-audio outputs were bitwise identical
    across five seeds.
  - Ten additional Base/Flash task comparisons were also bitwise identical.
  - This result is limited to the tested hardware, dtype, software versions,
    checkpoints, and inputs.
- Latency and GPU memory:

| Model | Input | Offload disabled | Offload enabled | VRAM saved | Median latency, off → on |
|---|---|---:|---:|---:|---:|
| AuK | Text only, 1.5 s output | 24.78 GiB | 16.75 GiB | 8.03 GiB (32.4%) | 2.036 s → 11.188 s |
| AuK | Approximately 5 s reference audio | 25.00 GiB | 16.98 GiB | 8.02 GiB (32.1%) | 2.554 s → 11.471 s |
| AuK-Flash | Text only, 1.5 s output | 24.77 GiB | 16.75 GiB | 8.02 GiB (32.4%) | 0.410 s → 9.025 s |
| AuK-Flash | Approximately 5 s reference audio | 24.97 GiB | 16.98 GiB | 7.99 GiB (32.0%) | 0.911 s → 9.360 s |

  VRAM values use `torch.cuda.max_memory_allocated`. Each latency result is the
  median of five measured runs after one warmup. Offload also increases host
  RAM usage because Qwen and DiT weights remain in CPU memory while idle.
- Public API or configuration:
  - Adds optional `cpu_offload: bool = False` to `AukInfer`.
  - Adds `--cpu_offload` to `auk-infer` and `auk-gradio`.
  - Adds optional `cpu_offload` to the ComfyUI model loader and cache key.
  - Default behavior remains unchanged.
- Checkpoint or data compatibility:
  - Existing Base and Flash checkpoints and configs remain compatible.
  - Existing ComfyUI workflows that omit `cpu_offload` continue to run with
    the default value `False`.
  - No checkpoint or data format changes.
- New dependencies:
  - `accelerate>=0.33.0` is moved from the training extra to core dependencies
    because inference offload imports it at runtime.

## Documentation and provenance

- [x] User-facing behavior, configuration, examples, and comments are updated where needed.
- [x] No credentials, private URLs, personal data, model weights, datasets, or generated artifact collections are committed.
- [x] Third-party code, models, data, and audio have documented sources and compatible licenses.
- [x] Submitted audio and data may legally and ethically be shared for the proposed use.
- [x] Material AI assistance is disclosed below, or no material AI assistance was used.

Documentation, provenance, and AI-assistance notes:

- `README.md` documents how to enable CPU offload and reports the measured peak
  VRAM before and after enabling it.
- `docs/COMFYUI.md` documents that Qwen and DiT are offloaded while the VAE
  remains resident on CUDA.
- No model weights, datasets, generated audio, private URLs, or credentials are
  included in this commit.
- Validation used the official `tencent/AuK`, `tencent/AuK-Flash`, and
  `Qwen/Qwen2.5-Omni-3B` model releases. These assets are not included in the
  PR.
- No audio or data is submitted by this PR; the checked item is therefore
  satisfied for the committed content.
- OpenAI Codex materially assisted with implementation iteration, test
  orchestration, result analysis, and PR-description drafting. The contributor
  reviewed the complete diff and is responsible for the submitted code and
  claims.

## Final checklist

- [x] The change is focused and the complete diff has been self-reviewed.
- [x] Unrelated formatting and generated edits have been removed.
- [x] Another contributor can reproduce the reported validation.
- [x] The contribution follows `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`.

## Reviewer notes

- The main implementation is in `src/auk/infer/infer_auk.py`.
- The VAE intentionally remains on CUDA. Offloading it required removing legacy
  `weight_norm`, which introduced deterministic numerical differences. Keeping
  it resident restored bitwise equality in all tested comparisons.
- Relative to also offloading the VAE, keeping it resident costs approximately
  1.03 GiB for text-only inference and 1.17 GiB for reference-audio inference,
  while avoiding VAE transfers and slightly improving measured latency.
- The large latency increase relative to no offload is primarily due to moving
  the Qwen and DiT weights between CPU and CUDA.
- `cpu_offload` remains disabled by default, so existing API and UI behavior is
  unchanged unless users opt in.
- A single model is still bound to one CUDA device; this change does not add
  tensor or model parallelism.
- AuK-Flash fp16 produced NaN/Inf with offload both disabled and enabled during
  broader testing. bf16 is the validated configuration; the fp16 issue is not
  introduced by this PR.
