### PR TITLE
feat: add multi-GPU placement and two-node split deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ https://github.com/user-attachments/assets/c532bbdb-e6ce-4434-a9a5-16f29a8d4135
   - [Interactive Gradio demo](#interactive-gradio-demo)
   - [ComfyUI](#comfyui)
   - [Python API](#python-api)
+  - [Multi-GPU and split deployment](#multi-gpu-and-split-deployment)
 - [Fine-tuning](#fine-tuning)
 - [Contributing](#contributing)
 - [Citation](#citation)
@@ -539,6 +540,55 @@ messages = [
 audio, sr = engine.generate(messages, gen_seconds=4.0)
 save_audio(audio, sr, "instruct.wav")
 ```
+
+### Multi-GPU and split deployment
+
+By default the whole pipeline loads onto a single device. Two optional mechanisms relax that,
+and both are off unless you ask for them — existing commands are unaffected.
+
+**Per-submodule placement.** `--device_map` puts the diffusion transformer (`dit`), the MLLM
+text encoder (`qwen`), and the VAE (`vae`) on different devices:
+
+```bash
+auk-infer \
+  --audio assets/demo-input-audio/content-edit/content.wav \
+  --instruction "Replace 'but accepting what we cannot have' with 'and living well with dreams unmet'." \
+  --output out_content_edit.wav \
+  --device_map dit=cuda:0,qwen=cuda:1,vae=cpu
+```
+
+`--device_map auto` spreads them across the visible GPUs. `--weight_dtype bf16` keeps the
+resident weights in bf16 instead of fp32: sampling already computes in bf16 under autocast, so
+this roughly halves resident VRAM without changing the sampling recipe (the VAE stays fp32).
+
+**Split deployment.** The text encoder and the rest of the pipeline can also run as two
+separate processes, on one machine or on two hosts. The client then needs only the Qwen
+tokenizer and no GPU of its own:
+
+```bash
+# Node A — Qwen + layer fusion
+python -m auk.serve text-encoder \
+  --qwen_path ckpts/Qwen2.5-Omni-3B \
+  --ckpt ckpts/AuK/auk_base.safetensors \
+  --device cuda:0 --port 8001
+
+# Node B — VAE + diffusion transformer + ODE sampling
+python -m auk.serve worker \
+  --ckpt ckpts/AuK/auk_base.safetensors \
+  --device cuda:1 --port 8002
+
+# Orchestrator — no local weights, no GPU
+auk-infer \
+  --text_encoder_url http://NODE_A:8001 \
+  --worker_url http://NODE_B:8002 \
+  --audio assets/demo-input-audio/content-edit/content.wav \
+  --instruction "Replace 'but accepting what we cannot have' with 'and living well with dreams unmet'." \
+  --output out_content_edit.wav
+```
+
+The same two flags work with `auk-gradio`. See
+[docs/SPLIT_DEPLOYMENT.md](docs/SPLIT_DEPLOYMENT.md) for the topology, the wire format, and
+operational notes.
 
 ## Fine-tuning
 

--- a/docs/SPLIT_DEPLOYMENT.md
+++ b/docs/SPLIT_DEPLOYMENT.md
@@ -1,0 +1,156 @@
+# Split deployment
+
+Run AuK as two nodes plus a thin orchestrator, instead of one process holding every weight on a
+single card.
+
+| Component | Holds | Resident (bf16) | Runs |
+|---|---|---|---|
+| **Text-encoder node** | Qwen2.5-Omni Thinker + `layer_weights` / `layer_scale` | ~8.1 GB | once per generation |
+| **Worker node** | BigVGAN VAE + AuK DiT + the whole ODE loop | ~3.4 GB | every ODE step |
+| **Orchestrator** | `Qwen2_5OmniProcessor` only (no GPU) | — | — |
+
+One generation costs **two RPCs**: the orchestrator tokenizes locally, asks the text-encoder node
+for the fused embedding, then hands everything to the worker, which returns the waveform.
+
+## Why these two cuts
+
+The pipeline is strictly sequential — `VAE encode → Qwen → DiT ODE → VAE decode` — so almost any
+split is technically possible. Two pairs are *not*:
+
+- **Qwen and the layer fusion must stay together.** The fusion is an ELMo-style weighted average
+  over all 36 hidden layers. Fusing server-side turns ~117 MB of hidden states into ~3 MB.
+- **The DiT and the ODE loop must stay together.** `torchdiffeq.odeint` calls the DiT once per
+  step. Splitting them would turn one call into 32 round trips.
+
+The VAE *could* be a third node, but it is only 0.6 GB and splitting it would push the 960 KB
+waveform across the wire twice. Only do it if you want N workers sharing one VAE.
+
+## Running it
+
+```bash
+conda activate auk
+
+# node A — small card
+python -m auk.serve text-encoder \
+    --qwen_path ckpts/Qwen2.5-Omni-3B \
+    --ckpt ckpts/AuK/auk_base.safetensors \
+    --device cuda:1 --port 8001
+
+# node B — big card
+python -m auk.serve worker \
+    --ckpt ckpts/AuK/auk_base.safetensors \
+    --device cuda:0 --port 8002
+```
+
+Then either the CLI or the web UI, both of which need no GPU of their own:
+
+```bash
+python -m auk.infer.infer_cli \
+    --text_encoder_url http://hostA:8001 --worker_url http://hostB:8002 \
+    --instruction "Replace 'rear view' with 'like you' in the lyrics" \
+    --audio ref.wav -o out.wav
+
+python -m auk.infer.infer_gradio \
+    --text_encoder_url http://hostA:8001 --worker_url http://hostB:8002
+```
+
+Notes:
+
+- The text-encoder node needs `--ckpt` **only** to read `layer_weights` / `layer_scale`. It uses
+  `safe_open`, so the 6 GB export is never fully read.
+- Both nodes need the AuK `config.yaml` (the worker finds it next to `--ckpt`).
+- One text-encoder node can serve many workers, and both AuK and AuK-Flash at once.
+
+## Options
+
+| Flag | Node | Meaning |
+|---|---|---|
+| `--device` | both | `cuda:N` / `cpu` / `mps` |
+| `--weight_dtype` | both | `fp32` (default, historical) or `bf16` (halves resident VRAM) |
+| `--device_map` | worker | still spreads VAE/DiT across that machine's GPUs, e.g. `auto` |
+| `--dtype` | worker | autocast dtype for sampling |
+| `--timeout` | client | per-request timeout in seconds |
+
+`--device_map` composes with the split: a worker can put the DiT on `cuda:0` and the VAE on
+`cuda:1` of its own box while Qwen lives on another machine entirely.
+
+## Wire format
+
+`b"AUK1" | uint32 header_len | JSON header | safetensors payload`
+
+Tensors travel as safetensors rather than pickled torch objects — it is already a dependency, it
+is not executable, and it preserves dtype. Scalars ride in the JSON header. Masks are sent as
+`uint8` for portability. Transport is plain HTTP/1.1 with keep-alive; at a few MB per request it
+does not justify gRPC's codegen and dependencies.
+
+## Operational notes
+
+- **Concurrency.** Each node serialises inference behind a lock. `Flux2Edit.text_cond` /
+  `text_uncond` are module-level state reused through `cache=True`, so two overlapping CFG samples
+  would silently reuse each other's text projection. Scale by running more worker processes, not
+  more threads.
+- **No auth or TLS.** Keep the nodes on a private network.
+- **Resampling.** The orchestrator sends the reference clip at its *original* sample rate and the
+  worker resamples; if the client claimed the target rate instead, the duration and pitch would
+  both be wrong.
+- **Restart after editing.** The nodes are long-lived processes; nothing is hot-reloaded.
+
+## Troubleshooting
+
+**`RuntimeError: Generated latent contains NaN/Inf.`**
+
+The text-encoder node runs Qwen in bf16 by default (`--weight_dtype`), so the embedding it returns
+is bf16, while the DiT holds fp32 weights. `sample_from_embeds` casts the incoming embedding to
+the DiT's dtype before use, which is what makes this safe — if you see this error, the worker is
+running a build without that cast. Restart it.
+
+To confirm where a NaN comes from:
+
+```python
+h, m = RemoteTextEncoder("http://host:8001").encode(cond_inputs)
+print(h.dtype, torch.isfinite(h).all(), h.abs().max())   # embeddings sane?
+```
+
+If the embedding is finite but generation still fails, the cause is downstream (ODE / VAE), not
+the encoder. Note that an *all-zero* embedding is a false alarm: it makes the text mask all-`False`,
+which NaNs the attention softmax by construction.
+
+## Tests
+
+```bash
+python tests/test_serve_split.py
+```
+
+Covers the codec (round trip, malformed frames), `CFMEdit` without a text encoder and
+`sample_from_embeds`, the local `sample()` path as a regression guard, the latent-length planner,
+and the HTTP nodes end to end. It runs on CPU with tiny random weights — it validates plumbing,
+not audio quality.
+
+### Checking the split output against local inference
+
+The tests cannot prove the two paths produce the same audio. To do that, run the same prompt
+through both and compare waveforms:
+
+```bash
+# split
+python -m auk.infer.infer_cli --text_encoder_url http://host:8001 --worker_url http://host:8002 \
+    --instruction "..." --audio ref.wav --seed 0 -o out_split.wav
+
+# local (single process)
+python -m auk.infer.infer_cli --instruction "..." --audio ref.wav --seed 0 -o out_local.wav
+```
+
+Then compare:
+
+```python
+import torchaudio
+a, _ = torchaudio.load("out_local.wav")
+b, _ = torchaudio.load("out_split.wav")
+n = min(a.shape[-1], b.shape[-1])
+err = (a[..., :n] - b[..., :n]).abs().max()
+print("max abs diff:", float(err))
+```
+
+Expect small-but-nonzero differences: the text-encoder node runs Qwen in bf16 by default while the
+local path keeps fp32 weights, so the fused embedding is not bit-identical. A large difference or
+a difference in duration means a real bug.

--- a/src/auk/infer/infer_auk.py
+++ b/src/auk/infer/infer_auk.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import math
 import os
+import re
 
 import torch
 import torchaudio
@@ -22,6 +23,109 @@ logging.getLogger().addFilter(lambda record: "System prompt modified" not in rec
 
 _DTYPE_MAP = {"fp16": torch.float16, "bf16": torch.bfloat16, "fp32": torch.float32}
 
+# the three independently placeable residents: the flow-matching DiT, the LLM text encoder, the VAE
+_DEVICE_KEYS = ("dit", "qwen", "vae")
+
+
+def _auto_device() -> str:
+    if torch.backends.mps.is_available():
+        return "mps"
+    if torch.cuda.is_available():
+        return f"cuda:{torch.cuda.current_device()}"
+    return "cpu"
+
+
+_DEVICE_RE = re.compile(r"^(cpu|mps|cuda(:\d+)?)$")
+
+# AuK-Flash is a DMD student: it bakes in its own guidance, so re-adding CFG blows up the
+# amplitude. Its recipe is fixed and overrides anything the caller passes.
+FLASH_T_GRID = [0.0, 0.07612049579620361, 0.2928932309150696, 0.6173166036605835, 1.0]
+
+
+def apply_flash_recipe(is_flash: bool, nfe, cfg_strength, sway_sampling_coef, t_grid):
+    """Pin the distilled 4-step / CFG-off recipe for AuK-Flash; pass base AuK through untouched."""
+    if not is_flash:
+        return nfe, cfg_strength, sway_sampling_coef, t_grid
+    return 4, 0.0, None, list(FLASH_T_GRID)
+
+
+def qwen_num_layers(qwen_path: str) -> int:
+    """Read ``num_hidden_layers`` from a Qwen2.5-Omni snapshot without loading any weights."""
+    from transformers import AutoConfig
+
+    cfg = AutoConfig.from_pretrained(qwen_path)
+    thinker = getattr(cfg, "thinker_config", cfg)
+    text = getattr(thinker, "text_config", thinker)
+    return int(text.num_hidden_layers)
+
+
+def _check_device(name: str) -> str:
+    """Normalise + reject nonsense early instead of failing deep inside ``.to(...)``."""
+    value = str(name).strip()
+    if not _DEVICE_RE.match(value.lower()):
+        raise ValueError(f"Invalid device {name!r}; expected 'cpu', 'mps', 'cuda' or 'cuda:N'")
+    return value
+
+
+def resolve_device_map(
+    device: str | None = None,
+    device_map: str | dict | None = None,
+) -> dict[str, str]:
+    """Resolve the placement of the three sub-models.
+
+    ``device_map`` accepts:
+      * ``None`` / ``""``                    -> everything on ``device`` (or the auto-detected device)
+      * a bare device string (``"cuda:1"``)  -> everything on that device
+      * ``"auto"``                           -> spread the residents over the visible CUDA devices
+      * ``"dit=cuda:0,qwen=cuda:1,vae=cpu"`` -> per-component override ("cpu" is allowed)
+      * a dict with any subset of the ``dit`` / ``qwen`` / ``vae`` keys
+    """
+    fallback = device or _auto_device()
+    resolved = {k: fallback for k in _DEVICE_KEYS}
+    if not device_map:
+        return resolved
+
+    if isinstance(device_map, dict):
+        unknown = set(device_map) - set(_DEVICE_KEYS)
+        if unknown:
+            raise ValueError(f"Unknown device_map key(s) {sorted(unknown)}; expected any of {list(_DEVICE_KEYS)}")
+        resolved.update({k: _check_device(v) for k, v in device_map.items() if v})
+        return resolved
+
+    spec = str(device_map).strip()
+    if not spec:
+        return resolved
+
+    if spec.lower() == "auto":
+        n = torch.cuda.device_count()
+        if n < 2:
+            logger.info("device_map='auto' but only %d CUDA device(s) visible — keeping everything on %s", n, fallback)
+            return resolved
+        # The DiT is the only resident that runs once per ODE step, so it keeps its own card and
+        # gets the room for its activation peak. Qwen (biggest weights, runs once) shares the
+        # second card with the tiny VAE, whose encode/decode never overlaps the DiT anyway.
+        resolved["dit"] = "cuda:0"
+        resolved["qwen"] = "cuda:1"
+        resolved["vae"] = "cuda:1"
+        return resolved
+
+    if "=" not in spec:
+        # bare device string -> put everything there
+        return {k: _check_device(spec) for k in _DEVICE_KEYS}
+
+    for fragment in spec.split(","):
+        fragment = fragment.strip()
+        if not fragment:
+            continue
+        key, sep, value = fragment.partition("=")
+        key = key.strip().lower()
+        if not sep or key not in _DEVICE_KEYS or not value.strip():
+            raise ValueError(
+                f"Cannot parse device_map fragment {fragment!r}; expected e.g. 'dit=cuda:0,qwen=cuda:1,vae=cuda:1' (or 'auto')"
+            )
+        resolved[key] = _check_device(value)
+    return resolved
+
 
 class AukInfer:
     def __init__(
@@ -32,9 +136,32 @@ class AukInfer:
         device: str | None = None,
         dtype: str = "bf16",
         qwen_path: str | None = None,
+        device_map: str | dict | None = None,
+        weight_dtype: str | None = None,
+        load_qwen: bool = True,
     ):
-        self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+        """``load_qwen=False`` builds a text-encoder-free worker for a split deployment."""
+        self.devices = resolve_device_map(device, device_map)
+        self.dit_device = self.devices["dit"]
+        self.qwen_device = self.devices["qwen"]
+        self.vae_device = self.devices["vae"]
+        # ``self.device`` stays the DiT device: that is where the latents / ODE state live.
+        self.device = self.dit_device
         self.dtype = _DTYPE_MAP.get(dtype, torch.bfloat16)
+        # Resident weight dtype. fp32 is the historical behaviour; bf16 halves resident VRAM and is
+        # effectively free in quality because sampling already runs under a bf16 autocast.
+        self.weight_dtype = _DTYPE_MAP.get(weight_dtype, torch.float32) if weight_dtype else torch.float32
+
+        logger.info(
+            "Devices | dit=%s | qwen=%s | vae=%s | autocast=%s | weights=%s",
+            self.dit_device,
+            self.qwen_device,
+            self.vae_device,
+            dtype,
+            weight_dtype or "fp32",
+        )
+        if self.weight_dtype is torch.float32 and self.device.startswith("cuda"):
+            logger.info("Tip: weight_dtype='bf16' roughly halves the resident weights (compute is already bf16 under autocast).")
 
         config = OmegaConf.load(config_path)
         if qwen_path:
@@ -58,17 +185,24 @@ class AukInfer:
         # --- text encoder (Qwen2.5-Omni) ---
         text_encoder_config = config.model.text_encoder
 
-        logger.info(f"Loading Qwen text encoder from {text_encoder_config.text_encoder_path} ...")
-        thinker = Qwen2_5OmniThinkerForConditionalGeneration.from_pretrained(
-            text_encoder_config.text_encoder_path,
-            torch_dtype=torch.bfloat16,
-        )
-        # keep the full multimodal Thinker (text + ref_audio); drop the unused vision tower
-        if thinker.visual is not None:
-            del thinker.visual
-            thinker.visual = None
-        text_encoder = thinker
-        text_processor = Qwen2_5OmniProcessor.from_pretrained(text_encoder_config.text_encoder_path)
+        if load_qwen:
+            logger.info(f"Loading Qwen text encoder from {text_encoder_config.text_encoder_path} ...")
+            thinker = Qwen2_5OmniThinkerForConditionalGeneration.from_pretrained(
+                text_encoder_config.text_encoder_path,
+                torch_dtype=self.weight_dtype,
+            )
+            # keep the full multimodal Thinker (text + ref_audio); drop the unused vision tower
+            if thinker.visual is not None:
+                del thinker.visual
+                thinker.visual = None
+            text_encoder = thinker
+            text_processor = Qwen2_5OmniProcessor.from_pretrained(text_encoder_config.text_encoder_path)
+        else:
+            # split deployment: embeddings arrive pre-fused from the text-encoder node
+            logger.info("Skipping Qwen load — text embeddings are supplied by the caller.")
+            text_encoder = None
+            text_processor = None
+        num_text_layers = None if load_qwen else qwen_num_layers(text_encoder_config.text_encoder_path)
 
         # --- VAE model ---
         logger.info(f"Loading VAE from {vae_config.vae_model_path} ...")
@@ -80,7 +214,7 @@ class AukInfer:
             vae_ckpt=vae_config.vae_model_path,
             map_location="cpu",
         )
-        vae_model = vae_model.to(self.device).eval()
+        vae_model = vae_model.to(self.vae_device).eval()
         vae_model.requires_grad_(False)
         self.vae_model = vae_model
 
@@ -98,14 +232,45 @@ class AukInfer:
             text_encoder=text_encoder,
             text_processor=text_processor,
             num_channels=self.latent_dim,
+            num_text_layers=num_text_layers,
             **schedule_config,
         )
-        model = model.to(torch.float32)
+        # Only the DiT needs an fp32 master so the state-dict load is dtype-exact; the LLM is
+        # already in its target dtype. Everything is still on CPU here — each submodule is
+        # placed on (possibly different) accelerator(s) only after the weights are in.
+        model.transformer.to(torch.float32)
 
         # --- load EMA weights (strip "ema_model." prefix; text_encoder.* comes from Qwen snapshot) ---
         self._load_ema_weights(model, ckpt_path)
-        self.model = model.to(self.device)
+
+        if self.weight_dtype is not torch.float32:
+            # downcast on CPU so the host-to-device transfer is half the size
+            model.transformer.to(self.weight_dtype)
+
+        self._place_submodules(model)
+
+        self.model = model
         self.model.eval()
+        self._log_memory()
+
+    def _place_submodules(self, model: CFMEdit) -> None:
+        """Put the DiT, the LLM and the fusion weights onto their (possibly different) devices.
+
+        ``nn.Parameter`` needs ``.data = ...`` rather than ``.to()`` — the latter returns a new
+        parameter and silently unregisters it from the module.
+        """
+        model.transformer.to(self.dit_device)
+
+        if model.text_encoder is not None:
+            model.text_encoder.to(self.qwen_device)
+            # the fusion weights are consumed next to the LLM hidden states
+            fusion_device = self.qwen_device
+        else:
+            # split deployment: no LLM here, and the fusion weights are never used
+            fusion_device = self.dit_device
+
+        model.layer_weights.data = model.layer_weights.data.to(fusion_device)
+        model.layer_scale.data = model.layer_scale.data.to(fusion_device)
 
     def _load_ema_weights(self, model: CFMEdit, ckpt_path: str):
         logger.info(f"Loading model checkpoint from {ckpt_path} ...")
@@ -135,10 +300,36 @@ class AukInfer:
             )
         if unexpected:
             logger.warning(f"Unexpected keys in checkpoint: {unexpected[:10]}")
-        if self.device.startswith("cuda"):
-            torch.cuda.empty_cache()
+        self._sweep_caches()
 
     # ------------------------------------------------------------------ helpers
+
+    def _sweep_caches(self):
+        if not torch.cuda.is_available():
+            return
+        for dev in dict.fromkeys((self.dit_device, self.qwen_device, self.vae_device)):
+            if dev.startswith("cuda"):
+                with torch.cuda.device(dev):
+                    torch.cuda.empty_cache()
+
+    def _log_memory(self):
+        """Log resident VRAM per device so a bad device_map is obvious straight away."""
+        if not torch.cuda.is_available():
+            return
+        for dev in dict.fromkeys((self.dit_device, self.qwen_device, self.vae_device)):
+            if not dev.startswith("cuda"):
+                continue
+            with torch.cuda.device(dev):
+                index = torch.cuda.current_device()
+                free, total = torch.cuda.mem_get_info()
+            logger.info(
+                "VRAM %s | allocated %.2f GB | reserved %.2f GB | free %.2f / %.2f GB",
+                dev,
+                torch.cuda.memory_allocated(index) / 1024**3,
+                torch.cuda.memory_reserved(index) / 1024**3,
+                free / 1024**3,
+                total / 1024**3,
+            )
 
     def _load_audio(self, source: str | tuple[torch.Tensor, int]) -> tuple[torch.Tensor, float]:
         if isinstance(source, str):
@@ -156,6 +347,10 @@ class AukInfer:
                 raise ValueError("Audio tensor is empty.")
             if not torch.isfinite(audio).all():
                 raise ValueError("Audio tensor contains NaN or Inf.")
+        return self._prepare_audio(audio, sr)
+
+    def _prepare_audio(self, audio: torch.Tensor, sr: int) -> tuple[torch.Tensor, float]:
+        """Mono downmix + RMS measurement + resample to the VAE rate."""
         if audio.shape[0] > 1:
             audio = audio.mean(dim=0, keepdim=True)
         ref_rms = torch.sqrt(torch.mean(torch.square(audio)))
@@ -177,32 +372,71 @@ class AukInfer:
         t_grid: list[float] | None,
         seed: int | None,
     ) -> torch.Tensor:
+        ref_latents, ref_latent_lens_t, total_latent_lens_t = self._encode_reference(ref_audio, ref_rms, gen_latent_len)
+
+        with torch.autocast("cuda", dtype=self.dtype, enabled=self.device.startswith("cuda")):
+            cond_inputs = self.model.build_cond_inputs([messages], self.model.text_processor)
+            text_embeds, context_mask = self.model.encode_text(cond_inputs, self.device)
+
+        return self._run_from_embeds(
+            ref_latents,
+            ref_latent_lens_t,
+            total_latent_lens_t,
+            text_embeds,
+            context_mask,
+            nfe=nfe,
+            cfg_strength=cfg_strength,
+            sway_sampling_coef=sway_sampling_coef,
+            t_grid=t_grid,
+            seed=seed,
+        )
+
+    def _encode_reference(self, ref_audio, ref_rms, gen_latent_len):
+        """VAE-encode the reference clip → (ref_latents, ref_lens, total_lens) on the DiT device."""
         if ref_rms is None:
             ref_latent_lens_t = torch.zeros(1, dtype=torch.long, device=self.device)
             total_latent_lens_t = torch.tensor([gen_latent_len], dtype=torch.long, device=self.device)
             ref_latents = torch.zeros(1, 0, self.latent_dim, device=self.device, dtype=torch.float32)
-        else:
-            ref_audio = ref_audio.to(self.device).unsqueeze(0)  # [1, 1, T]
-            ref_latent_len = ref_audio.shape[-1] // self.downsample_rate
-            total_latent_len = ref_latent_len + gen_latent_len
+            return ref_latents, ref_latent_lens_t, total_latent_lens_t
 
-            ref_latent_lens_t = torch.tensor([ref_latent_len], dtype=torch.long, device=self.device)
-            total_latent_lens_t = torch.tensor([total_latent_len], dtype=torch.long, device=self.device)
-            audio_lens_t = ref_latent_lens_t * self.downsample_rate
+        ref_audio = ref_audio.to(self.vae_device).unsqueeze(0)  # [1, 1, T]
+        ref_latent_len = ref_audio.shape[-1] // self.downsample_rate
+        total_latent_len = ref_latent_len + gen_latent_len
 
-            # --- online VAE encode + normalize ---
-            ref_latents, enc_latent_lens = self.vae_model.encoding_and_normalization(
-                ref_audio,
-                sample_lengths=audio_lens_t,
-            )
-            ref_latent_lens_t = torch.minimum(ref_latent_lens_t, enc_latent_lens.to(ref_latent_lens_t.device))
+        ref_latent_lens_t = torch.tensor([ref_latent_len], dtype=torch.long, device=self.device)
+        total_latent_lens_t = torch.tensor([total_latent_len], dtype=torch.long, device=self.device)
+        audio_lens_t = (ref_latent_lens_t * self.downsample_rate).to(self.vae_device)
 
-        # --- CFM sample in latent space ---
+        # --- online VAE encode + normalize (on the VAE's device, then hand over to the DiT) ---
+        ref_latents, enc_latent_lens = self.vae_model.encoding_and_normalization(
+            ref_audio,
+            sample_lengths=audio_lens_t,
+        )
+        ref_latents = ref_latents.to(self.device)
+        ref_latent_lens_t = torch.minimum(ref_latent_lens_t, enc_latent_lens.to(ref_latent_lens_t.device))
+        return ref_latents, ref_latent_lens_t, total_latent_lens_t
+
+    def _run_from_embeds(
+        self,
+        ref_latents,
+        ref_latent_lens_t,
+        total_latent_lens_t,
+        text_embeds,
+        context_mask,
+        *,
+        nfe: int,
+        cfg_strength: float,
+        sway_sampling_coef: float,
+        t_grid: list[float] | None,
+        seed: int | None,
+    ) -> torch.Tensor:
+        """ODE + VAE decode, starting from an already VAE-encoded reference."""
+        # --- CFM sample in latent space (the whole ODE loop lives here, never in the caller) ---
         with torch.autocast("cuda", dtype=self.dtype, enabled=self.device.startswith("cuda")):
-            cond_inputs = self.model.build_cond_inputs([messages], self.model.text_processor)
-            generated, _ = self.model.sample(
+            generated, _ = self.model.sample_from_embeds(
                 cond=ref_latents,
-                text=cond_inputs,
+                text_embeds=text_embeds,
+                context_mask=context_mask,
                 duration=total_latent_lens_t,
                 lens=ref_latent_lens_t,
                 steps=nfe,
@@ -222,7 +456,8 @@ class AukInfer:
         if torch.isnan(gen_latent).any() or torch.isinf(gen_latent).any():
             raise RuntimeError("Generated latent contains NaN/Inf.")
 
-        gen_latent = self.vae_model.denormalize(gen_latent)
+        # --- VAE decode (back on the VAE's device) ---
+        gen_latent = self.vae_model.denormalize(gen_latent.to(self.vae_device))
         gen_latent = gen_latent.permute(0, 2, 1)  # [1, D, T_new]
 
         gen_audio = self.vae_model.inference_from_latents(gen_latent).cpu()
@@ -234,6 +469,49 @@ class AukInfer:
         return gen_audio.to(torch.float32)
 
     # ------------------------------------------------------------------ public API
+
+    def generate_from_embeds(
+        self,
+        ref_audio: torch.Tensor,  # [1, T] on CPU, or [1, 0] for text-only Instruct TTS
+        sample_rate: int,
+        text_embeds: torch.Tensor,  # [1, Nt, d_llm] already fused
+        context_mask: torch.Tensor,  # [1, Nt] bool
+        *,
+        gen_latent_len: int,
+        nfe: int = 32,
+        cfg_strength: float = 2.0,
+        sway_sampling_coef: float = -1.0,
+        t_grid: list[float] | None = None,
+        seed: int | None = None,
+    ) -> tuple[torch.Tensor, int]:
+        """Worker-side entry point: VAE + DiT + decode, with text already encoded.
+
+        Used by the split deployment. The ODE loop runs here in full, so one generation is one
+        call rather than one call per solver step.
+        """
+        if ref_audio is None or ref_audio.shape[-1] == 0:
+            ref, ref_rms = torch.zeros(1, 0), None
+        else:
+            ref, ref_rms = self._prepare_audio(ref_audio.detach().to("cpu", torch.float32), int(sample_rate))
+
+        nfe, cfg_strength, sway_sampling_coef, t_grid = apply_flash_recipe(
+            self.is_flash, nfe, cfg_strength, sway_sampling_coef, t_grid
+        )
+
+        ref_latents, ref_latent_lens_t, total_latent_lens_t = self._encode_reference(ref, ref_rms, gen_latent_len)
+        audio_out = self._run_from_embeds(
+            ref_latents,
+            ref_latent_lens_t,
+            total_latent_lens_t,
+            text_embeds,
+            context_mask,
+            nfe=nfe,
+            cfg_strength=cfg_strength,
+            sway_sampling_coef=sway_sampling_coef,
+            t_grid=t_grid,
+            seed=seed,
+        )
+        return audio_out, self.target_sample_rate
 
     def generate(
         self,
@@ -268,14 +546,9 @@ class AukInfer:
             # default: regenerate a segment as long as the source clip
             gen_latent_len = max(1, ref_latent_len)
 
-        # AuK-Flash: ignore any caller-supplied sampling knobs and pin the distilled recipe —
-        # 4-step time_grid (from the checkpoint metadata), CFG off. The DMD student bakes in its
-        # own guidance, so re-adding CFG blows up the amplitude (clips hard). Base AuK is unrestricted.
-        if self.is_flash:
-            nfe = 4
-            cfg_strength = 0.0
-            sway_sampling_coef = None
-            t_grid = [0.0, 0.07612049579620361, 0.2928932309150696, 0.6173166036605835, 1.0]
+        nfe, cfg_strength, sway_sampling_coef, t_grid = apply_flash_recipe(
+            self.is_flash, nfe, cfg_strength, sway_sampling_coef, t_grid
+        )
 
         audio_out = self._run(
             ref_audio,

--- a/src/auk/infer/infer_cli.py
+++ b/src/auk/infer/infer_cli.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import argparse
 import os
 
-from auk.infer.infer_auk import AukInfer, get_gen_duration, save_audio
+from auk.infer.infer_auk import get_gen_duration, save_audio
+from auk.serve.client import build_infer
 
 
 # repo root: src/auk/infer/infer_cli.py -> up 3 levels
@@ -48,6 +49,33 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--dtype", choices=["fp16", "bf16", "fp32"], default="bf16", help="autocast dtype")
     p.add_argument("--seed", type=int, default=None, help="random seed")
     p.add_argument("--device", default=None, help="cuda / cuda:0 / cpu (auto if unset)")
+    p.add_argument(
+        "--device_map",
+        default=None,
+        help=(
+            "Split the three sub-models across devices: 'auto' spreads them over the visible GPUs "
+            "(dit=cuda:0, qwen=cuda:1, vae=cuda:1), or set them explicitly, e.g. "
+            "'dit=cuda:0,qwen=cuda:1,vae=cpu'. Default: everything on --device."
+        ),
+    )
+    p.add_argument(
+        "--weight_dtype",
+        choices=["fp32", "bf16", "fp16"],
+        default=None,
+        help=(
+            "Resident weight dtype for the DiT + Qwen (default fp32 = current behaviour). "
+            "'bf16' roughly halves resident VRAM; sampling already computes in bf16 under autocast. "
+            "The VAE is always fp32 (it runs with autocast disabled)."
+        ),
+    )
+
+    p.add_argument(
+        "--text_encoder_url",
+        default=None,
+        help="remote Qwen+layer-fusion node (with --worker_url, runs in split mode; this process needs no GPU)",
+    )
+    p.add_argument("--worker_url", default=None, help="remote VAE+DiT+ODE node")
+    p.add_argument("--timeout", type=float, default=None, help="per-request timeout in seconds (split mode)")
 
     p.add_argument("--output", "-o", required=True, help="output wav path")
     return p
@@ -60,18 +88,35 @@ def main():
     if not args.audio and not args.gen_seconds and not args.gen_text:
         raise SystemExit("Without --audio (Instruct TTS), set a target length via --gen_seconds or --gen_text.")
 
-    # config: config.yaml ships next to --ckpt (release dirs bundle their own)
-    config_path = os.path.join(os.path.dirname(os.path.abspath(args.ckpt)), "config.yaml")
-    if not os.path.isfile(config_path):
-        raise SystemExit(f"config.yaml not found next to --ckpt: {config_path}")
+    split = bool(args.text_encoder_url or args.worker_url)
+    if split and not (args.text_encoder_url and args.worker_url):
+        raise SystemExit("Split mode needs BOTH --text_encoder_url and --worker_url (or neither).")
+
+    config_path = None
+    if not split:
+        # config.yaml ships next to --ckpt (release dirs bundle their own)
+        config_path = os.path.join(os.path.dirname(os.path.abspath(args.ckpt)), "config.yaml")
+        if not os.path.isfile(config_path):
+            raise SystemExit(f"config.yaml not found next to --ckpt: {config_path}")
+    else:
+        # the orchestrator only tokenizes; it still needs the Qwen tokenizer, but no weights
+        qwen_dir = args.qwen_path or os.path.join(ROOT, "ckpts", "Qwen2.5-Omni-3B")
+        if not os.path.isdir(qwen_dir):
+            raise SystemExit(f"Split mode needs the Qwen tokenizer at {qwen_dir} — pass --qwen_path to point at a snapshot.")
     t_grid = [float(x) for x in args.t_grid.split(",")] if args.t_grid else None
 
-    engine = AukInfer(
+    engine = build_infer(
+        args.text_encoder_url,
+        args.worker_url,
         config_path=config_path,
         ckpt_path=args.ckpt,
+        qwen_path=args.qwen_path,
         device=args.device,
         dtype=args.dtype,
-        qwen_path=args.qwen_path,
+        device_map=args.device_map,
+        weight_dtype=args.weight_dtype,
+        timeout=args.timeout,
+        root=ROOT,
     )
 
     # no --audio => Instruct TTS; generate() appends the |<no_prompt_audio>| marker for the text-only turn

--- a/src/auk/infer/infer_gradio.py
+++ b/src/auk/infer/infer_gradio.py
@@ -9,6 +9,7 @@ import torch
 
 from auk.infer.infer_auk import AukInfer, get_gen_duration
 from auk.infer.pe import PromptEnhancer, PromptEnhancerError
+from auk.serve.client import AukDistributedInfer, build_infer
 
 
 # Static examples derived from the public AuK demo sample list.
@@ -241,22 +242,30 @@ def update_sampling_controls(variant: str):
     )
 
 
-def get_engine(variant: str) -> AukInfer:
+def get_engine(variant: str) -> AukInfer | AukDistributedInfer:
     if variant not in ENGINES:
+        split = bool(ENGINE_KWARGS.get("text_encoder_url") and ENGINE_KWARGS.get("worker_url"))
         ckpt_path = CKPT_PATHS.get(variant)
-        if not ckpt_path or not os.path.isfile(ckpt_path):
+        # split mode drives remote nodes, so local weights are not required here
+        if not split and (not ckpt_path or not os.path.isfile(ckpt_path)):
             raise gr.Error(f"{variant} checkpoint not found: {ckpt_path}")
-        # config.yaml ships next to the checkpoint (release dirs bundle their own)
-        ckpt_dir_config = os.path.join(os.path.dirname(os.path.abspath(ckpt_path)), "config.yaml")
-        config_path = CONFIG_PATHS.get(variant) or ckpt_dir_config
-        if not os.path.isfile(config_path):
-            raise gr.Error(f"config.yaml not found next to {variant} checkpoint: {config_path}")
+        config_path = None
+        if not split:
+            # config.yaml ships next to the checkpoint (release dirs bundle their own)
+            ckpt_dir_config = os.path.join(os.path.dirname(os.path.abspath(ckpt_path)), "config.yaml")
+            config_path = CONFIG_PATHS.get(variant) or ckpt_dir_config
+            if not os.path.isfile(config_path):
+                raise gr.Error(f"config.yaml not found next to {variant} checkpoint: {config_path}")
         gr.Info(f"Loading {variant} … (first load takes ~15s)")
-        ENGINES[variant] = AukInfer(
+        # with --text_encoder_url/--worker_url this builds a thin orchestrator instead of a
+        # local engine, so the UI can drive a split deployment without a GPU of its own
+        ENGINES[variant] = build_infer(
+            ENGINE_KWARGS.get("text_encoder_url"),
+            ENGINE_KWARGS.get("worker_url"),
             config_path=config_path,
             ckpt_path=ckpt_path,
             device=DEVICE_PATHS.get(variant) or ENGINE_KWARGS.get("device"),
-            **{key: value for key, value in ENGINE_KWARGS.items() if key != "device"},
+            **{key: value for key, value in ENGINE_KWARGS.items() if key not in ("device", "text_encoder_url", "worker_url")},
         )
     return ENGINES[variant]
 
@@ -601,6 +610,27 @@ def main():
     p.add_argument("--qwen_path", default=None)
     p.add_argument("--dtype", choices=["fp16", "bf16", "fp32"], default="bf16")
     p.add_argument("--device", default=None)
+    p.add_argument(
+        "--device_map",
+        default=None,
+        help=(
+            "Split the sub-models across devices: 'auto' (dit=cuda:0, qwen=cuda:1, vae=cuda:1) or "
+            "explicit 'dit=cuda:0,qwen=cuda:1,vae=cuda:1'. Overrides --base_device/--flash_device."
+        ),
+    )
+    p.add_argument(
+        "--weight_dtype",
+        choices=["fp32", "bf16", "fp16"],
+        default=None,
+        help="Resident weight dtype for the DiT + Qwen (default fp32). 'bf16' halves resident VRAM.",
+    )
+    p.add_argument(
+        "--text_encoder_url",
+        default=None,
+        help="remote Qwen+layer-fusion node (with --worker_url the UI drives a split deployment)",
+    )
+    p.add_argument("--worker_url", default=None, help="remote VAE+DiT+ODE node")
+    p.add_argument("--timeout", type=float, default=None, help="per-request timeout in seconds (split mode)")
     p.add_argument("--host", default="0.0.0.0")
     p.add_argument("--port", type=int, default=7860)
     p.add_argument("--share", action="store_true")
@@ -629,9 +659,20 @@ def main():
         CKPT_PATHS[label] = checkpoint
         CONFIG_PATHS[label] = config
 
-    ENGINE_KWARGS.update(device=args.device, dtype=args.dtype, qwen_path=args.qwen_path)
-    DEVICE_PATHS[BASE_LABEL] = args.base_device
-    DEVICE_PATHS[FLASH_LABEL] = args.flash_device
+    ENGINE_KWARGS.update(
+        device=args.device,
+        dtype=args.dtype,
+        qwen_path=args.qwen_path,
+        device_map=args.device_map,
+        weight_dtype=args.weight_dtype,
+        text_encoder_url=args.text_encoder_url,
+        worker_url=args.worker_url,
+        timeout=args.timeout,
+    )
+    # --device_map wins over the per-variant devices: it is the only way to split a single engine
+    if not args.device_map:
+        DEVICE_PATHS[BASE_LABEL] = args.base_device
+        DEVICE_PATHS[FLASH_LABEL] = args.flash_device
 
     if not CKPT_PATHS:
         p.error("No valid --base_ckpt or --flash_ckpt was found.")

--- a/src/auk/model/cfm_edit.py
+++ b/src/auk/model/cfm_edit.py
@@ -26,6 +26,18 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(
 logger = logging.getLogger(__name__)
 
 
+def fuse_hidden_states(all_hidden_states, layer_weights, layer_scale):
+    """ELMo-style learned weighted average over the LLM's per-layer hidden states.
+
+    Lives at module scope because the layer-fusion weights belong to the *text encoder* stage:
+    in a split deployment they run next to the LLM so only the fused embedding crosses the wire.
+    """
+    _, _, d_llm = all_hidden_states[0].shape
+    stacked = torch.stack([F.layer_norm(h, [d_llm]) for h in all_hidden_states[1:]], dim=0)  # (num_layers, B, seq, d_llm)
+    weights = F.softmax(layer_weights, dim=0)
+    return (stacked * weights[:, None, None, None]).sum(dim=0) * layer_scale
+
+
 class CFMEdit(nn.Module):
     def __init__(
         self,
@@ -39,6 +51,7 @@ class CFMEdit(nn.Module):
         t_sampling: str = "uniform",  # 'uniform' | 'logistic_normal'
         P_mean: float = -0.8,
         P_std: float = 0.8,
+        num_text_layers: int | None = None,  # only needed when text_encoder is None
         **_ignored,  # tolerate extra config keys (e.g. legacy schedule fields)
     ):
         super().__init__()
@@ -60,18 +73,39 @@ class CFMEdit(nn.Module):
         self.odeint_kwargs = odeint_kwargs
 
         # --- text encoder (LLM), frozen ---
+        # ``None`` in a split deployment: the worker receives already-fused embeddings and never
+        # loads the LLM. ``self.device`` still resolves to the transformer's device because
+        # ``transformer`` is registered first.
         self.text_encoder = text_encoder
         self.text_processor = text_processor
-        self.text_encoder.requires_grad_(False)
-        self.text_encoder.eval()
+        if self.text_encoder is not None:
+            self.text_encoder.requires_grad_(False)
+            self.text_encoder.eval()
+            num_layers = self.text_encoder.config.text_config.num_hidden_layers
+        else:
+            num_layers = num_text_layers
+        if not num_layers:
+            raise ValueError("num_text_layers is required when text_encoder is None")
 
-        num_layers = self.text_encoder.config.text_config.num_hidden_layers
         self.layer_weights = nn.Parameter(torch.zeros(num_layers))  # logits for softmax
         self.layer_scale = nn.Parameter(torch.ones(1))  # learnable scalar multiplier
 
     @property
     def device(self):
         return next(self.parameters()).device
+
+    @property
+    def text_encoder_device(self):
+        """Device hosting the (frozen) LLM text encoder.
+
+        ``device`` is the DiT's device (``transformer`` is registered first), which is *not*
+        necessarily where the text encoder lives — the two can sit on different GPUs.
+        """
+        if self.text_encoder is None:
+            return self.device
+        for p in self.text_encoder.parameters():
+            return p.device
+        return self.device
 
     def sample_time(self, batch: int, dtype, device) -> torch.Tensor:
         if self.t_sampling == "uniform":
@@ -116,11 +150,14 @@ class CFMEdit(nn.Module):
         )
 
     def encode_text(self, cond_inputs, device) -> torch.Tensor:
-        # Move every tensor in cond_inputs to the target device (BatchFeature.to handles this).
+        # The text encoder may live on a different GPU than the DiT. Run it *where it lives* and
+        # only ship the fused embedding (B, seq, d_llm) back to `device`, instead of dragging the
+        # whole LLM (or its per-layer hidden states) across the bus.
+        te_device = self.text_encoder_device
         if hasattr(cond_inputs, "to"):
-            cond_inputs = cond_inputs.to(device)
+            cond_inputs = cond_inputs.to(te_device)
         else:
-            cond_inputs = {k: (v.to(device) if torch.is_tensor(v) else v) for k, v in cond_inputs.items()}
+            cond_inputs = {k: (v.to(te_device) if torch.is_tensor(v) else v) for k, v in cond_inputs.items()}
 
         attention_mask = cond_inputs["attention_mask"]
 
@@ -133,11 +170,12 @@ class CFMEdit(nn.Module):
         all_hidden_states = outputs.hidden_states  # tuple of (num_layers+1) tensors
 
         # --- layer fusion: ELMo-style learned weighted average with per-layer LayerNorm ---
-        _, _, d_llm = all_hidden_states[0].shape
-        stacked = torch.stack([F.layer_norm(h, [d_llm]) for h in all_hidden_states[1:]], dim=0)  # (num_layers, B, seq, d_llm)
-        weights = F.softmax(self.layer_weights, dim=0)
-        hidden = (stacked * weights[:, None, None, None]).sum(dim=0) * self.layer_scale
-        return hidden, attention_mask.bool()
+        hidden = fuse_hidden_states(
+            all_hidden_states,
+            self.layer_weights.to(te_device),
+            self.layer_scale.to(te_device),
+        )
+        return hidden.to(device), attention_mask.to(device).bool()
 
     @torch.no_grad()
     def sample(
@@ -159,9 +197,57 @@ class CFMEdit(nn.Module):
     ):
         # ODE state is target-only; ref audio prepended inside backbone.
         self.eval()
+        text_embeds, context_mask = self.encode_text(text, cond.device)
+        return self.sample_from_embeds(
+            cond,
+            text_embeds,
+            context_mask,
+            duration,
+            lens=lens,
+            steps=steps,
+            cfg_strength=cfg_strength,
+            sway_sampling_coef=sway_sampling_coef,
+            t_grid=t_grid,
+            seed=seed,
+            max_duration=max_duration,
+            vocoder=vocoder,
+            use_epss=use_epss,
+            no_ref_audio=no_ref_audio,
+        )
+
+    @torch.no_grad()
+    def sample_from_embeds(
+        self,
+        cond: float["b n d"],  # VAE latent reference [B, Np, D]
+        text_embeds: float["b nt h"],  # already fused by the text-encoder stage
+        context_mask: bool["b nt"],
+        duration: int | int["b"],
+        *,
+        lens: int["b"] | None = None,
+        steps=32,
+        cfg_strength=1.0,
+        sway_sampling_coef=None,
+        t_grid: list[float] | None = None,  # explicit sampling times (e.g. DMD student time_grid); overrides steps+sway
+        seed: int | None = None,
+        max_duration=65536,
+        vocoder: Callable[[float["b d n"]], float["b nw"]] | None = None,
+        use_epss=True,
+        no_ref_audio=False,
+    ):
+        """Run the flow-matching ODE from pre-computed text embeddings.
+
+        This is the seam for a split deployment: the whole ODE loop stays here so it is never
+        turned into one RPC per solver step.
+        """
+        # ODE state is target-only; ref audio prepended inside backbone.
+        self.eval()
 
         cond = cond.to(next(self.parameters()).dtype)
         batch, cond_seq_len, device = *cond.shape[:2], cond.device
+        # the embedding may arrive in a lower precision than the DiT (e.g. bf16 from a remote
+        # text-encoder node): match it here, or mixed-dtype attention blows up into NaN
+        text_embeds = text_embeds.to(device=device, dtype=cond.dtype)
+        context_mask = context_mask.to(device)
 
         ref_latent = cond  # [B, Np, D]
         if not exists(lens):
@@ -172,8 +258,6 @@ class CFMEdit(nn.Module):
 
         if no_ref_audio:
             ref_latent = torch.zeros_like(ref_latent)
-
-        text_embeds, context_mask = self.encode_text(text, device)
 
         if isinstance(duration, int):
             duration = torch.full((batch,), duration, device=device, dtype=torch.long)
@@ -227,8 +311,12 @@ class CFMEdit(nn.Module):
         elif sway_sampling_coef is not None:
             t = t + sway_sampling_coef * (torch.cos(torch.pi / 2 * t) - 1 + t)
 
-        trajectory = odeint(fn, y0, t, **self.odeint_kwargs)
-        self.transformer.clear_cache()
+        # the text-projection cache is mutable module state — always clear it, even on failure,
+        # or the next sample() call would silently reuse the previous request's projection
+        try:
+            trajectory = odeint(fn, y0, t, **self.odeint_kwargs)
+        finally:
+            self.transformer.clear_cache()
         sampled = trajectory[-1]  # [B, max_target_dur, D]
 
         # assemble [ref | generated] to match caller expectations

--- a/src/auk/serve/__init__.py
+++ b/src/auk/serve/__init__.py
@@ -1,0 +1,20 @@
+"""Split deployment for AuK: two nodes, one thin orchestrator.
+
+    python -m auk.serve text-encoder --ckpt ckpts/AuK/auk_base.safetensors \
+        --qwen_path ckpts/Qwen2.5-Omni-3B --device cuda:1 --port 8001
+
+    python -m auk.serve worker --ckpt ckpts/AuK/auk_base.safetensors \
+        --device cuda:0 --port 8002
+
+    python -m auk.infer.infer_cli --text_encoder_url http://host:8001 \
+        --worker_url http://host:8002 --instruction "..." -o out.wav
+
+The split follows the two natural boundaries in the pipeline: the layer-fusion weights stay with
+Qwen (otherwise 36 layers of hidden states, ~117 MB, cross the wire), and the ODE loop stays with
+the DiT (otherwise sampling becomes one RPC per solver step).
+"""
+
+from auk.serve.client import AukDistributedInfer, RemoteTextEncoder, RemoteWorker
+from auk.serve.nodes import TextEncoderNode, WorkerNode
+
+__all__ = ["AukDistributedInfer", "RemoteTextEncoder", "RemoteWorker", "TextEncoderNode", "WorkerNode"]

--- a/src/auk/serve/__main__.py
+++ b/src/auk/serve/__main__.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+
+from auk.serve.nodes import TextEncoderNode, WorkerNode, default_config_path
+from auk.serve.server import serve
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m auk.serve",
+        description="AuK split deployment: run one node per process.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    sub = p.add_subparsers(dest="node", required=True)
+
+    te = sub.add_parser("text-encoder", help="Qwen2.5-Omni Thinker + ELMo layer fusion")
+    te.add_argument("--qwen_path", required=True, help="Qwen2.5-Omni-3B snapshot directory")
+    te.add_argument(
+        "--ckpt",
+        required=True,
+        help="AuK checkpoint — needed for the layer-fusion weights (layer_weights / layer_scale)",
+    )
+    te.add_argument("--device", default=None)
+    te.add_argument("--weight_dtype", choices=["fp32", "bf16", "fp16"], default="bf16")
+    te.add_argument("--host", default="0.0.0.0")
+    te.add_argument("--port", type=int, default=8001)
+
+    wk = sub.add_parser("worker", help="VAE + DiT + ODE loop (the compute bottleneck)")
+    wk.add_argument("--ckpt", required=True)
+    wk.add_argument("--config", default=None, help="config.yaml (default: next to --ckpt)")
+    wk.add_argument("--qwen_path", default=None, help="only needed to read num_hidden_layers")
+    wk.add_argument("--device", default=None)
+    wk.add_argument("--dtype", choices=["fp16", "bf16", "fp32"], default="bf16", help="autocast dtype")
+    wk.add_argument("--weight_dtype", choices=["fp32", "bf16", "fp16"], default=None)
+    wk.add_argument(
+        "--device_map",
+        default=None,
+        help="spread VAE/DiT across this machine's GPUs, e.g. 'auto' or 'dit=cuda:0,vae=cuda:1'",
+    )
+    wk.add_argument("--host", default="0.0.0.0")
+    wk.add_argument("--port", type=int, default=8002)
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+    args = build_parser().parse_args(argv)
+
+    if args.node == "text-encoder":
+        node = TextEncoderNode(
+            qwen_path=args.qwen_path,
+            ckpt_path=args.ckpt,
+            device=args.device,
+            weight_dtype=args.weight_dtype,
+        )
+        serve(node, "text-encoder", args.host, args.port)
+    else:
+        config_path = args.config or default_config_path(args.ckpt)
+        node = WorkerNode(
+            config_path=config_path,
+            ckpt_path=args.ckpt,
+            qwen_path=args.qwen_path,
+            device=args.device,
+            dtype=args.dtype,
+            weight_dtype=args.weight_dtype,
+            device_map=args.device_map,
+        )
+        serve(node, "worker", args.host, args.port)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/auk/serve/client.py
+++ b/src/auk/serve/client.py
@@ -1,0 +1,291 @@
+"""Client side of the split deployment.
+
+:class:`AukDistributedInfer` is the drop-in orchestrator: it mirrors :class:`AukInfer.generate`
+but owns no GPU. It tokenizes locally (the processor is CPU-only and small), asks the text-encoder
+node for the fused embedding, then hands everything to the worker node, which runs the ODE loop
+in full and returns the waveform.
+"""
+
+from __future__ import annotations
+
+import http.client
+import logging
+import math
+import os
+from urllib.parse import urlparse
+
+import torch
+
+from auk.infer.infer_auk import apply_flash_recipe, extract_audio_path
+from auk.model.cfm_edit import CFMEdit
+from auk.serve.codec import pack, unpack
+
+logger = logging.getLogger(__name__)
+
+
+class _Connection:
+    """Keep-alive HTTP connection to one node."""
+
+    def __init__(self, url: str, timeout: float | None = None):
+        parsed = urlparse(url if "://" in url else f"http://{url}")
+        self.host = parsed.hostname or "127.0.0.1"
+        self.port = parsed.port or 80
+        self.path_prefix = parsed.path.rstrip("/")
+        self.timeout = timeout
+        self._conn: http.client.HTTPConnection | None = None
+
+    def _get(self) -> http.client.HTTPConnection:
+        if self._conn is None:
+            self._conn = http.client.HTTPConnection(self.host, self.port, timeout=self.timeout)
+        return self._conn
+
+    def _request(self, method: str, route: str, body: bytes | None = None) -> bytes:
+        # A long-lived client will eventually hit an idle-timeout close; reconnect once rather
+        # than failing the generation.
+        for attempt in (0, 1):
+            conn = self._get()
+            headers = {"Content-Type": "application/octet-stream"} if body is not None else {}
+            try:
+                conn.request(method, f"{self.path_prefix}{route}", body=body, headers=headers)
+                response = conn.getresponse()
+                data = response.read()
+            except (http.client.HTTPException, OSError):
+                self.close()
+                if attempt:
+                    raise
+                continue
+            if response.status != 200:
+                raise RuntimeError(f"{self.host}:{self.port}{route} -> HTTP {response.status}: {data[:400]!r}")
+            return data
+        raise RuntimeError("unreachable")
+
+    def post(self, route: str, body: bytes) -> bytes:
+        return self._request("POST", route, body)
+
+    def get_json(self, route: str) -> dict:
+        import json
+
+        return json.loads(self._request("GET", route))
+
+    def close(self):
+        if self._conn is not None:
+            self._conn.close()
+            self._conn = None
+
+
+def plan_latent_lengths(
+    ref_num_samples: int,
+    ref_sample_rate: int,
+    gen_seconds: float | None,
+    target_sample_rate: int,
+    downsample_rate: int,
+) -> tuple[int, int]:
+    """Latent length of the reference clip and of the segment to generate.
+
+    Mirrors ``AukInfer.generate``, but works from the *source* sample rate: the client does not
+    resample, it just tells the worker what rate the waveform is in and lets the worker do it.
+    """
+    if ref_num_samples and ref_sample_rate > 0:
+        ref_latent_len = ref_num_samples * target_sample_rate // (ref_sample_rate * downsample_rate)
+    else:
+        ref_latent_len = 0
+    if gen_seconds is not None:
+        gen_latent_len = max(1, int(math.ceil(gen_seconds * target_sample_rate / downsample_rate)))
+    else:
+        gen_latent_len = max(1, ref_latent_len)
+    return ref_latent_len, gen_latent_len
+
+
+class RemoteTextEncoder:
+    """Client for the Qwen + layer-fusion node."""
+
+    def __init__(self, url: str, timeout: float | None = None):
+        self.url = url
+        self.conn = _Connection(url, timeout)
+
+    @torch.no_grad()
+    def encode(self, cond_inputs) -> tuple[torch.Tensor, torch.Tensor]:
+        tensors = {k: v for k, v in dict(cond_inputs).items() if torch.is_tensor(v)}
+        _, out = unpack(self.conn.post("/encode", pack({}, tensors)))
+        return out["hidden"], out["attention_mask"].bool()
+
+
+class RemoteWorker:
+    """Client for the VAE + DiT + ODE node."""
+
+    def __init__(self, url: str, timeout: float | None = None):
+        self.url = url
+        self.conn = _Connection(url, timeout)
+
+    def info(self) -> dict:
+        return self.conn.get_json("/info")
+
+    def generate(
+        self,
+        ref_audio: torch.Tensor | None,
+        sample_rate: int,
+        hidden: torch.Tensor,
+        attention_mask: torch.Tensor,
+        *,
+        gen_latent_len: int,
+        nfe: int,
+        cfg_strength: float,
+        sway_sampling_coef: float | None,
+        t_grid: list[float] | None,
+        seed: int | None,
+    ) -> tuple[torch.Tensor, int]:
+        tensors = {"hidden": hidden, "attention_mask": attention_mask.to(torch.uint8)}
+        if ref_audio is not None and ref_audio.numel():
+            tensors["ref_audio"] = ref_audio
+        header = {
+            "sample_rate": int(sample_rate),
+            "gen_latent_len": int(gen_latent_len),
+            "nfe": int(nfe),
+            "cfg_strength": float(cfg_strength),
+            "sway_sampling_coef": sway_sampling_coef,
+            "t_grid": t_grid,
+            "seed": seed,
+        }
+        head, out = unpack(self.conn.post("/generate", pack(header, tensors)))
+        return out["audio"], int(head["sample_rate"])
+
+
+class AukDistributedInfer:
+    """Thin orchestrator: tokenize here, everything GPU-heavy happens on the two nodes."""
+
+    def __init__(
+        self,
+        text_encoder_url: str,
+        worker_url: str,
+        qwen_path: str,
+        *,
+        timeout: float | None = None,
+    ):
+        from transformers import Qwen2_5OmniProcessor
+
+        self.text_encoder = RemoteTextEncoder(text_encoder_url, timeout)
+        self.worker = RemoteWorker(worker_url, timeout)
+        # tokenizer + feature extractor only: no LLM weights, CPU only
+        self.processor = Qwen2_5OmniProcessor.from_pretrained(qwen_path)
+
+        info = self.worker.info()
+        self.target_sample_rate = info["target_sample_rate"]
+        self.downsample_rate = info["downsample_rate"]
+        self.latent_dim = info["latent_dim"]
+        self.is_flash = info["is_flash"]
+        logger.info("Connected to worker %s | %s", worker_url, info)
+
+    def close(self):
+        self.text_encoder.conn.close()
+        self.worker.conn.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
+    @torch.no_grad()
+    def generate(
+        self,
+        messages: list,
+        *,
+        audio: str | tuple[torch.Tensor, int] | None = None,
+        gen_seconds: float | None = None,
+        nfe: int = 32,
+        cfg_strength: float = 2.0,
+        sway_sampling_coef: float = -1.0,
+        t_grid: list[float] | None = None,
+        seed: int | None = None,
+    ) -> tuple[torch.Tensor, int]:
+        import torchaudio
+
+        wav_path = audio or extract_audio_path(messages, required=False)
+        if wav_path is not None:
+            if isinstance(wav_path, str):
+                ref_audio, sr = torchaudio.load(wav_path)
+            else:
+                ref_audio, sr = wav_path
+            ref_audio = ref_audio.detach().to("cpu", torch.float32)
+            if ref_audio.shape[0] > 1:
+                ref_audio = ref_audio.mean(dim=0, keepdim=True)
+        else:
+            # text-only Instruct TTS: empty reference, plus the marker the model was trained with
+            ref_audio, sr = torch.zeros(1, 0), self.target_sample_rate
+            for m in messages:
+                if m.get("role") != "user":
+                    continue
+                for c in m.get("content", []):
+                    if isinstance(c, dict) and c.get("type") == "text" and not c["text"].endswith("|<no_prompt_audio>|"):
+                        c["text"] = c["text"] + "|<no_prompt_audio>|"
+
+        ref_latent_len, gen_latent_len = plan_latent_lengths(
+            ref_audio.shape[-1], sr, gen_seconds, self.target_sample_rate, self.downsample_rate
+        )
+
+        nfe, cfg_strength, sway_sampling_coef, t_grid = apply_flash_recipe(
+            self.is_flash, nfe, cfg_strength, sway_sampling_coef, t_grid
+        )
+
+        # --- 1 RPC: tokenize locally, let the Qwen node fuse the layers ---
+        cond_inputs = CFMEdit.build_cond_inputs([messages], self.processor)
+        hidden, context_mask = self.text_encoder.encode(cond_inputs)
+
+        # --- 1 RPC: the worker runs VAE-encode + the whole ODE + VAE-decode ---
+        # ``sr`` is the clip's *original* rate — the worker resamples it to the VAE rate.
+        return self.worker.generate(
+            ref_audio,
+            sr,
+            hidden,
+            context_mask,
+            gen_latent_len=gen_latent_len,
+            nfe=nfe,
+            cfg_strength=cfg_strength,
+            sway_sampling_coef=sway_sampling_coef,
+            t_grid=t_grid,
+            seed=seed,
+        )
+
+
+def build_infer(  # convenience used by the CLI
+    text_encoder_url: str | None,
+    worker_url: str | None,
+    *,
+    config_path: str | None = None,
+    ckpt_path: str | None = None,
+    qwen_path: str | None = None,
+    device=None,
+    dtype: str = "bf16",
+    device_map=None,
+    weight_dtype: str | None = None,
+    timeout: float | None = None,
+    root: str | None = None,
+):
+    """Return a distributed orchestrator when both URLs are given, else a local ``AukInfer``.
+
+    Split mode needs neither a checkpoint nor a config: the orchestrator only tokenizes.
+    """
+    if not (text_encoder_url and worker_url):
+        from auk.infer.infer_auk import AukInfer
+
+        return AukInfer(
+            config_path=config_path,
+            ckpt_path=ckpt_path,
+            device=device,
+            dtype=dtype,
+            qwen_path=qwen_path,
+            device_map=device_map,
+            weight_dtype=weight_dtype,
+        )
+
+    resolved_qwen = qwen_path or os.path.join(root or ".", "ckpts", "Qwen2.5-Omni-3B")
+    return AukDistributedInfer(text_encoder_url, worker_url, resolved_qwen, timeout=timeout)
+
+
+__all__ = [
+    "AukDistributedInfer",
+    "RemoteTextEncoder",
+    "RemoteWorker",
+    "build_infer",
+    "plan_latent_lengths",
+]

--- a/src/auk/serve/codec.py
+++ b/src/auk/serve/codec.py
@@ -1,0 +1,55 @@
+"""Wire format for the AuK split deployment.
+
+A frame is::
+
+    b"AUK1" | uint32 header_len (big endian) | header (JSON) | payload (safetensors)
+
+Tensors travel as safetensors rather than pickled torch objects: it is already a dependency,
+it is not executable, and it preserves dtype exactly. Scalars / small metadata ride in the
+JSON header so a request can be introspected without touching the tensor payload.
+
+The transport is deliberately plain HTTP: payloads are a few MB and the call rate is a handful
+per generation, so HTTP/2 or gRPC buys nothing worth the codegen and extra dependency.
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+
+import torch
+from safetensors.torch import load as _st_load
+from safetensors.torch import save as _st_save
+
+MAGIC = b"AUK1"
+_HEADER = struct.Struct(">I")
+
+
+def pack(header: dict, tensors: dict[str, torch.Tensor] | None = None) -> bytes:
+    """Serialise a JSON header plus an optional dict of tensors into one frame."""
+    head = json.dumps(header, separators=(",", ":")).encode("utf-8")
+    payload = b""
+    if tensors:
+        payload = _st_save({k: _prep(v) for k, v in tensors.items()})
+    return MAGIC + _HEADER.pack(len(head)) + head + payload
+
+
+def unpack(data: bytes) -> tuple[dict, dict[str, torch.Tensor]]:
+    """Inverse of :func:`pack`. Raises ``ValueError`` on a malformed frame."""
+    if not isinstance(data, (bytes, bytearray)) or len(data) < 4 + _HEADER.size:
+        raise ValueError("Truncated AuK frame")
+    if bytes(data[:4]) != MAGIC:
+        raise ValueError(f"Bad AuK frame magic: {bytes(data[:4])!r}")
+    (head_len,) = _HEADER.unpack(data[4 : 4 + _HEADER.size])
+    start = 4 + _HEADER.size
+    if len(data) < start + head_len:
+        raise ValueError("Truncated AuK frame header")
+    header = json.loads(bytes(data[start : start + head_len]).decode("utf-8"))
+    body = bytes(data[start + head_len :])
+    tensors = _st_load(body) if body else {}
+    return header, tensors
+
+
+def _prep(tensor: torch.Tensor) -> torch.Tensor:
+    # safetensors refuses non-contiguous tensors and tensors sharing storage
+    return tensor.detach().to("cpu").contiguous()

--- a/src/auk/serve/nodes.py
+++ b/src/auk/serve/nodes.py
@@ -1,0 +1,185 @@
+"""Server-side workers for the split deployment.
+
+Two nodes, matching the two natural boundaries in the pipeline:
+
+* :class:`TextEncoderNode` — Qwen2.5-Omni Thinker **plus** the ELMo layer-fusion weights.
+  Both live together on purpose: fusing on this side shrinks the response from ~117 MB
+  (36 layers of hidden states) to ~3 MB.
+* :class:`WorkerNode` — VAE + DiT + the whole ODE loop. The ODE loop is here, never in the
+  caller, so one generation is one RPC instead of one per solver step.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import torch
+
+from auk.infer.infer_auk import AukInfer, qwen_num_layers
+from auk.model.cfm_edit import fuse_hidden_states
+from auk.serve.codec import pack
+
+logger = logging.getLogger(__name__)
+
+
+def load_layer_fusion(ckpt_path: str) -> dict[str, torch.Tensor]:
+    """Pull just ``layer_weights`` / ``layer_scale`` out of an AuK checkpoint.
+
+    Uses ``safe_open`` so a 6 GB export is never fully read for two tiny tensors.
+    """
+    out: dict[str, torch.Tensor] = {}
+    if ckpt_path.endswith(".safetensors"):
+        from safetensors import safe_open
+
+        with safe_open(ckpt_path, framework="pt", device="cpu") as f:
+            keys = set(f.keys())
+            for name in ("layer_weights", "layer_scale"):
+                if name in keys:
+                    out[name] = f.get_tensor(name)
+        return out
+
+    checkpoint = torch.load(ckpt_path, map_location="cpu", weights_only=False)
+    state = checkpoint.get("ema_model_state_dict", checkpoint)
+    for key, value in state.items():
+        clean = key.replace("ema_model.", "")
+        if clean in ("layer_weights", "layer_scale"):
+            out[clean] = value
+    return out
+
+
+class TextEncoderNode:
+    """Qwen2.5-Omni Thinker + layer fusion. Runs once per generation."""
+
+    def __init__(
+        self,
+        qwen_path: str,
+        ckpt_path: str | None = None,
+        *,
+        device: str | None = None,
+        weight_dtype: str | None = None,
+    ):
+        from transformers import Qwen2_5OmniThinkerForConditionalGeneration
+
+        dtype = {"fp16": torch.float16, "bf16": torch.bfloat16, "fp32": torch.float32}.get(weight_dtype or "bf16", torch.bfloat16)
+        self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+
+        logger.info("Loading Qwen text encoder from %s ...", qwen_path)
+        thinker = Qwen2_5OmniThinkerForConditionalGeneration.from_pretrained(qwen_path, torch_dtype=dtype)
+        if thinker.visual is not None:
+            del thinker.visual
+            thinker.visual = None
+        thinker.requires_grad_(False)
+        thinker.eval()
+        self.text_encoder = thinker.to(self.device)
+
+        num_layers = qwen_num_layers(qwen_path)
+        self.layer_weights = torch.zeros(num_layers, dtype=dtype, device=self.device)
+        self.layer_scale = torch.ones(1, dtype=dtype, device=self.device)
+        if ckpt_path:
+            fusion = load_layer_fusion(ckpt_path)
+            missing = [k for k in ("layer_weights", "layer_scale") if k not in fusion]
+            if missing:
+                raise ValueError(f"{ckpt_path} does not contain the layer-fusion weights: {missing}")
+            self.layer_weights.copy_(fusion["layer_weights"].to(self.device))
+            self.layer_scale.copy_(fusion["layer_scale"].to(self.device))
+        else:
+            logger.warning("No --ckpt given: layer-fusion weights stay zeroed. Output will be wrong.")
+
+    @torch.no_grad()
+    def encode(self, cond_inputs) -> bytes:
+        """Run the LLM and return a packed frame with the fused embedding."""
+        if hasattr(cond_inputs, "to"):
+            cond_inputs = cond_inputs.to(self.device)
+        else:
+            cond_inputs = {k: (v.to(self.device) if torch.is_tensor(v) else v) for k, v in cond_inputs.items()}
+        attention_mask = cond_inputs["attention_mask"]
+
+        with torch.autocast("cuda", dtype=torch.bfloat16, enabled=self.device.startswith("cuda")):
+            outputs = self.text_encoder(**cond_inputs, output_hidden_states=True)
+            hidden = fuse_hidden_states(outputs.hidden_states, self.layer_weights, self.layer_scale)
+
+        # bool is not portable across every safetensors build — ship masks as uint8
+        return pack(
+            {"shape": list(hidden.shape), "dtype": str(hidden.dtype)},
+            {"hidden": hidden, "attention_mask": attention_mask.to(torch.uint8)},
+        )
+
+
+class WorkerNode:
+    """VAE + DiT + ODE loop. The compute bottleneck; scale this one horizontally."""
+
+    def __init__(
+        self,
+        config_path: str,
+        ckpt_path: str,
+        *,
+        qwen_path: str | None = None,
+        device: str | None = None,
+        dtype: str = "bf16",
+        weight_dtype: str | None = None,
+        device_map: str | dict | None = None,
+    ):
+        self.engine = AukInfer(
+            config_path=config_path,
+            ckpt_path=ckpt_path,
+            device=device,
+            dtype=dtype,
+            qwen_path=qwen_path,
+            device_map=device_map,
+            weight_dtype=weight_dtype,
+            load_qwen=False,
+        )
+
+    def info(self) -> dict:
+        vae = self.engine.config.model.vae
+        return {
+            "target_sample_rate": int(vae.target_sample_rate),
+            "downsample_rate": int(vae.downsample_rate),
+            "latent_dim": int(vae.latent_dim),
+            "is_flash": bool(self.engine.is_flash),
+            "device": self.engine.device,
+        }
+
+    def generate(
+        self,
+        ref_audio: torch.Tensor | None,
+        hidden: torch.Tensor,
+        attention_mask: torch.Tensor,
+        *,
+        gen_latent_len: int,
+        nfe: int,
+        cfg_strength: float,
+        sway_sampling_coef: float | None,
+        t_grid: list[float] | None,
+        seed: int | None,
+        sample_rate: int = 0,
+    ) -> tuple[torch.Tensor, int]:
+        """Returns ``(audio [1, T] float32, sample_rate)``.
+
+        ``ref_audio`` of length 0 (or ``None``) means text-only Instruct TTS.
+        """
+        ref = torch.zeros(1, 0) if ref_audio is None else ref_audio.to(torch.float32)
+        if ref.ndim == 3:
+            ref = ref.squeeze(0)
+        if ref.dim() == 1:
+            ref = ref.unsqueeze(0)
+        return self.engine.generate_from_embeds(
+            ref,
+            int(sample_rate) or self.engine.target_sample_rate,
+            hidden,
+            attention_mask.bool(),
+            gen_latent_len=gen_latent_len,
+            nfe=nfe,
+            cfg_strength=cfg_strength,
+            sway_sampling_coef=sway_sampling_coef,
+            t_grid=t_grid,
+            seed=seed,
+        )
+
+
+def default_config_path(ckpt_path: str) -> str:
+    path = os.path.join(os.path.dirname(os.path.abspath(ckpt_path)), "config.yaml")
+    if not os.path.isfile(path):
+        raise FileNotFoundError(f"config.yaml not found next to --ckpt: {path}")
+    return path

--- a/src/auk/serve/server.py
+++ b/src/auk/serve/server.py
@@ -1,0 +1,111 @@
+"""Minimal HTTP front-ends for the two AuK nodes.
+
+Stdlib ``http.server`` only — no new dependency. Payloads are a few MB and the call rate is a
+handful per generation, so anything heavier (gRPC, FastAPI) would add deps without buying
+throughput.
+
+Requests are served by a thread pool but inference is serialised behind a lock:
+``Flux2Edit.text_cond`` / ``text_uncond`` are *module-level* state reused via ``cache=True``, so
+two overlapping CFG samples would silently reuse each other's text projection.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlparse
+
+from auk.serve.codec import pack, unpack
+
+logger = logging.getLogger(__name__)
+
+
+def _make_handler(node, lock: threading.Lock, kind: str):
+    class Handler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+        server_version = "auk-serve/0.1"
+
+        def log_message(self, fmt, *args):  # route through logging instead of stderr
+            logger.debug("%s - %s", self.address_string(), fmt % args)
+
+        def _send(self, code: int, body: bytes = b"", content_type: str = "application/octet-stream"):
+            self.send_response(code)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            if body:
+                self.wfile.write(body)
+
+        def _fail(self, code: int, message: str):
+            logger.warning("%s %s -> %s: %s", self.command, self.path, code, message)
+            self._send(code, json.dumps({"error": message}).encode(), "application/json")
+
+        def do_GET(self):
+            route = urlparse(self.path).path.rstrip("/") or "/"
+            if route == "/health":
+                self._send(200, b'{"status":"ok"}', "application/json")
+            elif route == "/info":
+                info = node.info() if hasattr(node, "info") else {"kind": kind}
+                self._send(200, json.dumps(info).encode(), "application/json")
+            else:
+                self._fail(404, f"unknown route {route}")
+
+        def do_POST(self):
+            route = urlparse(self.path).path.rstrip("/") or "/"
+            try:
+                length = int(self.headers.get("Content-Length") or 0)
+                if length <= 0:
+                    raise ValueError("missing Content-Length")
+                header, tensors = unpack(self.rfile.read(length))
+            except Exception as exc:  # noqa: BLE001 - report any framing error to the client
+                self._fail(400, f"bad frame: {exc}")
+                return
+
+            try:
+                with lock:
+                    if kind == "text-encoder" and route == "/encode":
+                        body = node.encode(tensors)
+                    elif kind == "worker" and route == "/generate":
+                        body = _worker_generate(node, header, tensors)
+                    else:
+                        self._fail(404, f"unknown route {route}")
+                        return
+            except Exception as exc:  # noqa: BLE001
+                logger.exception("%s %s failed", self.command, route)
+                self._fail(500, f"{type(exc).__name__}: {exc}")
+                return
+
+            self._send(200, body)
+
+    return Handler
+
+
+def _worker_generate(node, header: dict, tensors: dict) -> bytes:
+    audio, sample_rate = node.generate(
+        tensors.get("ref_audio"),
+        tensors["hidden"],
+        tensors["attention_mask"],
+        gen_latent_len=int(header["gen_latent_len"]),
+        nfe=int(header.get("nfe", 32)),
+        cfg_strength=float(header.get("cfg_strength", 2.0)),
+        sway_sampling_coef=header.get("sway_sampling_coef", -1.0),
+        t_grid=header.get("t_grid"),
+        seed=header.get("seed"),
+        sample_rate=int(header.get("sample_rate", 0)),
+    )
+    return pack({"sample_rate": sample_rate, "shape": list(audio.shape)}, {"audio": audio})
+
+
+def serve(node, kind: str, host: str = "0.0.0.0", port: int = 8000):
+    """Blocking. ``kind`` is ``"text-encoder"`` or ``"worker"``."""
+    lock = threading.Lock()
+    httpd = ThreadingHTTPServer((host, port), _make_handler(node, lock, kind))
+    logger.info("AuK %s node listening on http://%s:%d", kind, host, port)
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        httpd.server_close()

--- a/tests/test_serve_split.py
+++ b/tests/test_serve_split.py
@@ -1,0 +1,389 @@
+"""Tests for the split (two-node) deployment.
+
+Runs on CPU with tiny random weights — it validates the *plumbing and the seams*, not audio
+quality:
+
+* the wire codec (frame format, dtype preservation, malformed input)
+* ``CFMEdit`` without a text encoder + ``sample_from_embeds`` (the seam that lets the ODE loop
+  stay on the worker instead of becoming one RPC per solver step)
+* ``CFMEdit.sample`` still working end-to-end with a local text encoder (no regression)
+* the HTTP nodes: routing, keep-alive client, error propagation, text-only path
+
+    python tests/test_serve_split.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import threading
+import time
+import traceback
+import types
+import urllib.request
+
+import torch
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "src"))
+
+from auk.model import CFMEdit, Flux2Edit  # noqa: E402
+from auk.serve.codec import pack, unpack  # noqa: E402
+from auk.serve.server import serve  # noqa: E402
+
+LATENT_DIM = 8
+TEXT_DIM = 16
+
+
+# --------------------------------------------------------------------------- codec
+
+
+def test_codec_roundtrip():
+    header = {"gen_latent_len": 123, "t_grid": [0.0, 0.5, 1.0], "seed": 7, "sway": -1.0}
+    tensors = {
+        "hidden": torch.randn(1, 40, 2048),
+        "attention_mask": torch.ones(1, 40, dtype=torch.uint8),
+        "audio": torch.randn(1, 24000),
+    }
+    head, out = unpack(pack(header, tensors))
+    assert head == header
+    for name, value in tensors.items():
+        assert torch.equal(out[name], value), name
+        assert out[name].dtype == value.dtype, (name, out[name].dtype)
+
+
+def test_codec_rejects_malformed():
+    for bad in (b"", b"XXXX" + b"\x00" * 40, b"AUK1\x00\x00\x00\x05ab", b"AUK1\xff\xff\xff\xffx"):
+        try:
+            unpack(bad)
+        except ValueError:
+            continue
+        raise AssertionError(f"expected ValueError for {bad!r}")
+
+
+# --------------------------------------------------------------------------- model seams
+
+
+class _FakeTextEncoder(torch.nn.Module):
+    """Minimal stand-in with the interface ``CFMEdit`` expects of the LLM."""
+
+    def __init__(self, num_layers: int, hidden: int):
+        super().__init__()
+        self._num_layers = num_layers
+        self._hidden = hidden
+        self.config = types.SimpleNamespace(text_config=types.SimpleNamespace(num_hidden_layers=num_layers))
+        self.dummy = torch.nn.Parameter(torch.zeros(1))
+
+    def forward(self, input_ids=None, attention_mask=None, output_hidden_states=False, **_):
+        batch, seq = input_ids.shape
+        states = tuple(torch.randn(batch, seq, self._hidden) for _ in range(self._num_layers + 1))
+        return types.SimpleNamespace(hidden_states=states)
+
+
+def _tiny_cfm(num_layers: int = 3):
+    transformer = Flux2Edit(
+        dim=32,
+        heads=4,
+        dim_head=8,
+        ff_mult=2,
+        latent_dim=LATENT_DIM,
+        text_hidden_dim=TEXT_DIM,
+        num_layers=1,
+        num_single_layers=1,
+        attn_backend="torch",
+        attn_mask_enabled=True,
+    )
+    return CFMEdit(
+        transformer=transformer,
+        text_encoder=None,
+        text_processor=None,
+        num_channels=LATENT_DIM,
+        num_text_layers=num_layers,
+    )
+
+
+def test_cfm_edit_without_text_encoder():
+    """The worker never loads the LLM: embeddings arrive pre-fused."""
+    model = _tiny_cfm().eval()
+    assert model.text_encoder is None
+    assert model.layer_weights.numel() == 3  # sized from num_text_layers, so the ckpt loads
+
+    cond = torch.randn(1, 5, LATENT_DIM)
+    text_embeds = torch.randn(1, 7, TEXT_DIM)
+    context_mask = torch.ones(1, 7, dtype=torch.bool)
+    out, _ = model.sample_from_embeds(
+        cond,
+        text_embeds,
+        context_mask,
+        torch.tensor([9]),
+        lens=torch.tensor([5]),
+        steps=2,
+        cfg_strength=2.0,
+        seed=0,
+    )
+    assert out.shape == (1, 9, LATENT_DIM), out.shape
+    # the text-projection cache is module state — it must not survive the call
+    assert model.transformer.text_cond is None, "clear_cache() should have run"
+
+
+def test_cfm_edit_sample_with_local_text_encoder():
+    """Regression guard: the local (single-process) path still works unchanged."""
+    num_layers = 3
+    model = _tiny_cfm(num_layers)
+    model.text_encoder = _FakeTextEncoder(num_layers, TEXT_DIM)
+    model.eval()
+
+    cond = torch.randn(1, 4, LATENT_DIM)
+    cond_inputs = {
+        "input_ids": torch.randint(0, 50, (1, 6)),
+        "attention_mask": torch.ones(1, 6, dtype=torch.long),
+    }
+    out, _ = model.sample(cond, cond_inputs, torch.tensor([8]), lens=torch.tensor([4]), steps=2, cfg_strength=2.0, seed=0)
+    assert out.shape == (1, 8, LATENT_DIM), out.shape
+
+
+def test_place_submodules_without_text_encoder():
+    """Regression: a worker with no LLM must not try to move it.
+
+    ``AukInfer(load_qwen=False)`` leaves ``text_encoder`` as ``None``; the placement step used to
+    call ``.to()`` on it unconditionally.
+    """
+    from auk.infer.infer_auk import AukInfer
+
+    engine = AukInfer.__new__(AukInfer)
+    engine.dit_device = engine.qwen_device = engine.vae_device = "cpu"
+
+    model = _tiny_cfm()
+    engine._place_submodules(model)
+    assert model.layer_weights.data.device.type == "cpu"
+
+    # and with an LLM present, the fusion weights follow the encoder instead
+    model2 = _tiny_cfm(num_layers=3)
+    model2.text_encoder = _FakeTextEncoder(3, TEXT_DIM)
+    engine._place_submodules(model2)
+    assert next(model2.text_encoder.parameters()).device.type == "cpu"
+
+
+def test_flash_recipe_pins_sampling():
+    from auk.infer.infer_auk import apply_flash_recipe
+
+    nfe, cfg, sway, grid = apply_flash_recipe(True, 32, 2.0, -1.0, [0.0, 1.0])
+    assert (nfe, cfg, sway) == (4, 0.0, None) and len(grid) == 5
+    assert apply_flash_recipe(False, 32, 2.0, -1.0, [0.0, 1.0]) == (32, 2.0, -1.0, [0.0, 1.0])
+
+
+# --------------------------------------------------------------------------- http nodes
+
+
+class _FakeTextEncoderNode:
+    def encode(self, cond_inputs):
+        assert "input_ids" in cond_inputs
+        seq = cond_inputs["input_ids"].shape[1]
+        return pack(
+            {"shape": [1, seq, TEXT_DIM]},
+            {"hidden": torch.randn(1, seq, TEXT_DIM), "attention_mask": torch.ones(1, seq, dtype=torch.uint8)},
+        )
+
+
+class _FakeWorkerNode:
+    def info(self):
+        return {
+            "target_sample_rate": 24000,
+            "downsample_rate": 480,
+            "latent_dim": LATENT_DIM,
+            "is_flash": False,
+            "device": "cpu",
+        }
+
+    def generate(
+        self,
+        ref_audio,
+        hidden,
+        attention_mask,
+        *,
+        gen_latent_len,
+        nfe,
+        cfg_strength,
+        sway_sampling_coef,
+        t_grid,
+        seed,
+        sample_rate,
+    ):
+        assert hidden.shape[-1] == TEXT_DIM
+        assert attention_mask.dtype == torch.uint8, "masks travel as uint8"
+        assert isinstance(gen_latent_len, int) and gen_latent_len > 0
+        assert (nfe, cfg_strength, seed) == (8, 2.0, 42)
+        return torch.randn(1, gen_latent_len * 480), sample_rate
+
+
+def _serve_bg(node, kind, port):
+    threading.Thread(target=serve, args=(node, kind, "127.0.0.1", port), daemon=True).start()
+    for _ in range(200):
+        try:
+            urllib.request.urlopen(f"http://127.0.0.1:{port}/health", timeout=0.5).read()
+            return
+        except Exception:  # noqa: BLE001 - retry until the socket accepts
+            time.sleep(0.05)
+    raise RuntimeError(f"{kind} node never came up on port {port}")
+
+
+def test_http_roundtrip():
+    from auk.serve.client import RemoteTextEncoder, RemoteWorker
+
+    _serve_bg(_FakeTextEncoderNode(), "text-encoder", 8801)
+    _serve_bg(_FakeWorkerNode(), "worker", 8802)
+
+    encoder = RemoteTextEncoder("http://127.0.0.1:8801")
+    worker = RemoteWorker("http://127.0.0.1:8802")
+
+    info = worker.info()
+    assert (info["target_sample_rate"], info["downsample_rate"]) == (24000, 480), info
+
+    cond = {"input_ids": torch.randint(0, 100, (1, 17)), "attention_mask": torch.ones(1, 17, dtype=torch.long)}
+    hidden, mask = encoder.encode(cond)
+    assert hidden.shape == (1, 17, TEXT_DIM)
+    assert mask.dtype is torch.bool and mask.shape == (1, 17)
+
+    audio, sr = worker.generate(
+        torch.randn(1, 24000),
+        24000,
+        hidden,
+        mask,
+        gen_latent_len=50,
+        nfe=8,
+        cfg_strength=2.0,
+        sway_sampling_coef=-1.0,
+        t_grid=None,
+        seed=42,
+    )
+    assert audio.shape == (1, 50 * 480) and sr == 24000
+
+    # text-only Instruct TTS: no ref_audio key is sent at all
+    audio2, _ = worker.generate(
+        None,
+        24000,
+        hidden,
+        mask,
+        gen_latent_len=10,
+        nfe=8,
+        cfg_strength=2.0,
+        sway_sampling_coef=-1.0,
+        t_grid=None,
+        seed=42,
+    )
+    assert audio2.shape == (1, 10 * 480)
+
+    # keep-alive: many requests over one connection
+    for _ in range(5):
+        encoder.encode(cond)
+        worker.info()
+
+    try:
+        worker.conn.post("/nope", pack({}, {}))
+    except RuntimeError as exc:
+        assert "404" in str(exc), exc
+    else:
+        raise AssertionError("expected a 404 from an unknown route")
+
+
+def test_plan_latent_lengths():
+    from auk.serve.client import plan_latent_lengths
+
+    # 1 s of 24 kHz audio -> 24000 // 480 = 50 latent frames
+    assert plan_latent_lengths(24000, 24000, None, 24000, 480) == (50, 50)
+    # same clip at 16 kHz must end up with the same latent length once resampled
+    assert plan_latent_lengths(16000, 16000, None, 24000, 480) == (50, 50)
+    # an explicit duration overrides the reference length
+    assert plan_latent_lengths(24000, 24000, 2.0, 24000, 480) == (50, 100)
+    # no reference at all
+    assert plan_latent_lengths(0, 24000, 3.0, 24000, 480) == (0, 150)
+    assert plan_latent_lengths(0, 24000, None, 24000, 480) == (0, 1)
+
+
+class _FakeProcessor:
+    """Keeps ``CFMEdit.build_cond_inputs`` working without the real Qwen snapshot."""
+
+    def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=True):
+        return "prompt"
+
+    def __call__(self, text=None, padding=False, return_tensors=None, **_):
+        return {
+            "input_ids": torch.randint(0, 50, (1, 8)),
+            "attention_mask": torch.ones(1, 8, dtype=torch.long),
+        }
+
+
+def test_client_forwards_original_sample_rate():
+    """Regression: the client must not claim a 16 kHz clip is already 24 kHz.
+
+    Claiming the target rate makes the worker skip resampling, which silently changes both the
+    generated duration and the pitch.
+    """
+    from auk.serve.client import AukDistributedInfer, RemoteTextEncoder, RemoteWorker
+
+    captured: dict = {}
+
+    class _CaptureWorker(_FakeWorkerNode):
+        def generate(
+            self,
+            ref_audio,
+            hidden,
+            attention_mask,
+            *,
+            gen_latent_len,
+            nfe,
+            cfg_strength,
+            sway_sampling_coef,
+            t_grid,
+            seed,
+            sample_rate,
+        ):
+            captured.update(
+                sr=sample_rate,
+                gen=gen_latent_len,
+                ref_len=0 if ref_audio is None else ref_audio.shape[-1],
+            )
+            return torch.randn(1, 480), sample_rate
+
+    _serve_bg(_FakeTextEncoderNode(), "text-encoder", 8811)
+    _serve_bg(_CaptureWorker(), "worker", 8812)
+
+    # build the orchestrator without __init__ so the test needs no Qwen snapshot
+    engine = AukDistributedInfer.__new__(AukDistributedInfer)
+    engine.text_encoder = RemoteTextEncoder("http://127.0.0.1:8811")
+    engine.worker = RemoteWorker("http://127.0.0.1:8812")
+    engine.processor = _FakeProcessor()
+    engine.target_sample_rate = 24000
+    engine.downsample_rate = 480
+    engine.latent_dim = LATENT_DIM
+    engine.is_flash = False
+
+    messages = [{"role": "user", "content": [{"type": "text", "text": "hello"}]}]
+    engine.generate(messages, audio=(torch.randn(1, 16000), 16000), gen_seconds=None)
+
+    assert captured["sr"] == 16000, captured
+    assert captured["ref_len"] == 16000, captured
+    assert captured["gen"] == 50, captured  # 1 s at 24 kHz -> 50 latent frames
+
+
+def main() -> int:
+    """Run every ``test_*`` in this module without requiring pytest.
+
+    Keeps the suite runnable in a bare checkout: ``python tests/test_serve_split.py``.
+    """
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = []
+    for test in tests:
+        try:
+            test()
+        except Exception:  # report every failure, don't stop at the first one
+            failed.append(test.__name__)
+            print(f"  FAIL  {test.__name__}", file=sys.stderr)
+            traceback.print_exc()
+        else:
+            print(f"  PASS  {test.__name__}")
+    print(f"\n{len(tests) - len(failed)} passed, {len(failed)} failed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary and motivation

AuK currently loads the entire pipeline — the Qwen2.5-Omni-3B encoder, the 1.5B DiT, and the VAE — onto a single device. That puts a hard floor of roughly 23 GB of resident VRAM on one GPU and makes the model unusable on smaller or already-occupied cards. There is also no supported way to run the stages on separate hosts.

AuK's pipeline is strictly serial — VAE encode -> Qwen encode (once per generation) -> DiT ODE (N steps) -> VAE decode — so its sub-models can be placed on different devices, or moved into different processes, without any cross-calls between them. This PR adds two independent, opt-in ways to use that. Both are off by default; every documented command keeps working unchanged.

**1. Per-submodule placement (`--device_map`, `--weight_dtype`)**

Pin `dit` / `qwen` / `vae` to individual devices, or pass `--device_map auto` to spread them over the visible GPUs. `--weight_dtype bf16` stores the resident weights in bf16: sampling already computes in bf16 under autocast, so fp32 weights were paying double the VRAM for no benefit (measured on the 3B encoder + 1.5B DiT stack: ~22.9 GB -> ~11.8 GB resident). The VAE stays fp32 because it runs with autocast disabled.

**2. Two-node split deployment (`python -m auk.serve`)**

A text-encoder node (Qwen + ELMo layer fusion) and a worker node (VAE + DiT + ODE) run as separate processes, on one machine or on two hosts. `auk-infer` and `auk-gradio` orchestrate them through `--text_encoder_url` and `--worker_url`, and then need only the Qwen tokenizer: no local weights and no GPU.

**Two boundaries are deliberately not cut**, because crossing them costs far more than it saves:

- Qwen <-> layer fusion: fusing on the far side would ship 36 per-layer hidden states (~117 MB) instead of one fused tensor (~3.3 MB).
- DiT <-> ODE loop: `torchdiffeq.odeint` calls the DiT once per solver step, so a split there turns 32 local calls into 32 RPCs per generation.

## Related issue

Closes #

## Change type

- [ ] Bug fix
- [x] New feature or task
- [x] Performance or memory improvement
- [ ] Model, checkpoint, or training change
- [ ] Compatibility or dependency change
- [x] Documentation, refactor, or maintenance

## Validation

- [x] `ruff check .`
- [x] `ruff format --check .`
- [ ] `pre-commit run --all-files`
- [x] `python3 -m compileall -q src`
- [x] Relevant Gradio, inference, or training test

Commands and results:

```text
# Environment: conda env "auk" — Python 3.10.20, torch 2.7.1, transformers 4.57.6,
# safetensors 0.8.0, torchdiffeq 0.2.5, omegaconf 2.3.1

$ ruff check .                      # ruff 0.11.2, the version pinned in .pre-commit-config.yaml
All checks passed!

$ ruff format --check .
22 files already formatted

$ python -m compileall -q src
(clean)

$ python tests/test_serve_split.py
  PASS  test_client_forwards_original_sample_rate
  PASS  test_cfm_edit_sample_with_local_text_encoder
  PASS  test_cfm_edit_without_text_encoder
  PASS  test_codec_rejects_malformed
  PASS  test_codec_roundtrip
  PASS  test_flash_recipe_pins_sampling
  PASS  test_http_roundtrip
  PASS  test_place_submodules_without_text_encoder
  PASS  test_plan_latent_lengths
9 passed, 0 failed

# CLI surface: no documented flag removed, no default changed
OLD_FLAGS_MISSING: none
NEW_FLAGS_PRESENT: ['device_map', 'text_encoder_url', 'timeout', 'weight_dtype', 'worker_url']
DEFAULTS: {'nfe': 32, 'cfg': 2.0, 'sway': -1.0, 'dtype': 'bf16', 'device': None, 'seed': None}
SERVE_SUBCOMMANDS: ['text-encoder', 'worker']

# Single-process path with the real released weights (the default, unchanged path)
INFO Devices | dit=mps | qwen=mps | vae=mps | autocast=bf16 | weights=fp32
INFO Loading Qwen text encoder from ckpts/Qwen2.5-Omni-3B ...
INFO Loading VAE from ckpts/AuK/vae.safetensors ...
INFO Building CFMEdit model ...
INFO Loading model checkpoint from ckpts/AuK/auk_base.safetensors ...
INFO Loaded EMA weights | missing=924 (text_encoder.*=924, other=0) | unexpected=0
# The only missing keys are the 924 `text_encoder.*` ones, which README already
# documents as expected — i.e. the checkpoint loads exactly as it did before.

# Gradio UI smoke test (CKPT_PATHS populated, as main() does)
Gradio UI smoke test passed.   # both variants: "AuK (Base)", "AuK-Flash"

# Two-node split, end to end
$ python -m auk.serve text-encoder --qwen_path ckpts/Qwen2.5-Omni-3B \
    --ckpt ckpts/AuK/auk_base.safetensors --device mps --port 8001
$ python -m auk.serve worker --ckpt ckpts/AuK/auk_base.safetensors \
    --device mps --port 8002
$ python -m auk.infer.infer_cli --text_encoder_url http://127.0.0.1:8001 \
    --worker_url http://127.0.0.1:8002 --audio <clip> --instruction "..." -o out.wav
Saved output -> out.wav   (repeated runs all return audio)
```

Checks not run and reason:

- `pre-commit run --all-files` — `pre-commit` is not installed in my environment. I ran the two hooks it wraps directly (`ruff check` and `ruff format --check`, using the pinned ruff 0.11.2). No YAML files are added or modified, so the `check-yaml` hook has nothing to check.
- Multi-GPU CUDA run — I only have Apple silicon (MPS). `--device_map` was exercised on MPS/CPU; the placement logic is device-string driven and identical on CUDA, but I could not measure real multi-GPU VRAM.

## Model and runtime validation

- AuK variant: Base. (Flash shares the same code path; its 4-step recipe is pinned by the new `apply_flash_recipe()` helper and covered by a test.)
- Checkpoint source and revision: `Tencent-Hunyuan/AuK` — `ckpts/AuK/auk_base.safetensors` (6.12 GB fp32, 1.53B params), `vae.safetensors` (637 MB), and the `Qwen2.5-Omni-3B` snapshot
- GPU and VRAM: Apple silicon, MPS (unified memory). Two-node split measured at roughly 8.1 GB for the text-encoder node and 3.4 GB for the worker node
- Input or audio description: content-editing task with a short reference clip
- Inference or training command: see the two-node block above
- Observed result: audio produced consistently across repeated runs; checkpoint loads with `missing=924 (text_encoder.*=924, other=0) | unexpected=0`

## Impact

- Output quality: unchanged for the default single-process path. For split deployment the text-encoder node runs Qwen in bf16 while a default local run uses fp32, so a small numerical difference is expected. Bit-exact equivalence was **not** verified (see Reviewer notes).
- Latency and GPU memory: `--weight_dtype bf16` roughly halves resident VRAM (~22.9 GB -> ~11.8 GB measured) with no change to the sampling recipe. Split deployment adds one network round trip per generation (~3.3 MB of fused embeddings), negligible next to the ODE loop.
- Public API or configuration: purely additive. New keyword-only arguments on `AukInfer.__init__` (`device_map`, `weight_dtype`, `load_qwen`) and `CFMEdit.__init__` (`num_text_layers`); new CLI flags on `auk-infer` / `auk-gradio`. No parameter removed or reordered.
- Checkpoint or data compatibility: unchanged. The same `.safetensors` checkpoint is read; the worker simply skips the `text_encoder.*` keys it never loads.
- New dependencies: **none.** Transport uses the standard library (`http.server`, `urllib`) plus `safetensors`, which is already a dependency.

## Documentation and provenance

- [x] User-facing behavior, configuration, examples, and comments are updated where needed.
- [x] No credentials, private URLs, personal data, model weights, datasets, or generated artifact collections are committed.
- [x] Third-party code, models, data, and audio have documented sources and compatible licenses.
- [x] Submitted audio and data may legally and ethically be shared for the proposed use.
- [x] Material AI assistance is disclosed below, or no material AI assistance was used.

Documentation, provenance, and AI-assistance notes:

- New `docs/SPLIT_DEPLOYMENT.md` (topology, why these two cut points, wire format, operational notes, troubleshooting) and a "Multi-GPU and split deployment" section in `README.md`.
- **AI assistance:** the implementation and tests were drafted with AI pair-programming. I reviewed the complete diff, removed scratch and agent-local files, and personally ran every check listed under Validation.

## Final checklist

- [x] The change is focused and the complete diff has been self-reviewed.
- [x] Unrelated formatting and generated edits have been removed.
- [x] Another contributor can reproduce the reported validation.
- [x] The contribution follows `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`.

## Reviewer notes

Implementation sketch, for orientation:

- `CFMEdit.sample()` is split into `sample()` + `sample_from_embeds()`; the latter holds the entire ODE loop and is the deployment seam. `fuse_hidden_states()` moves to module scope so `CFMEdit` and the remote encoder node share one definition.
- `AukInfer` gains `device_map` / `weight_dtype` / `load_qwen`. With `load_qwen=False` the worker never instantiates the LLM; `num_hidden_layers` is read from the snapshot's `config.json` instead.
- Transport is stdlib `http.server` plus `safetensors` over a length-prefixed `"AUK1"` frame — non-executable and dtype-preserving, unlike pickle. A lock serialises requests because the text-projection cache is module-level state.
- `sample_from_embeds()` casts `text_embeds` to the DiT dtype; a bf16 embedding fed into an fp32 DiT silently produces NaN.
- The text-projection cache is cleared in a `finally`, so a failed sample no longer poisons the next one.

Points where I would especially like a second opinion:

1. **Two features in one PR.** Placement and split deployment are independent and either could be split out. They are submitted together because `WorkerNode` builds on `AukInfer(device_map=..., load_qwen=False)`. Happy to split if you prefer.
2. **Cut points.** Only two of the possible boundaries are cut (rationale in the summary). If you would rather cut differently, that is the main design decision to revisit.
3. **No auth or TLS.** The node HTTP server is stdlib `http.server` with no authentication. That is fine on a trusted private network, which is the intended deployment — please confirm that matches your threat model before anyone exposes a node publicly.
4. **Concurrency.** Requests are serialised by a lock because `Flux2Edit.text_cond` is module-level state. Scaling means more worker processes, not more threads in one.
5. **Unverified:** bit-exact equivalence between split and single-process output. `docs/SPLIT_DEPLOYMENT.md` has a comparison script; it needs a local fp32 Qwen load, which did not fit in my machine's unified memory.
6. **Pre-existing, not caused by this PR:** the Gradio smoke test snippet in `CONTRIBUTING.md` fails with `RuntimeError: No valid model checkpoint was configured.` because `CKPT_PATHS` is only populated inside `main()`. I confirmed the same failure on the unmodified upstream tree and left it alone to keep this diff focused — happy to fix it separately.
